### PR TITLE
Improving the async WMI model to expose parameters to the callbacks

### DIFF
--- a/go/cim/WmiEventSink_test.go
+++ b/go/cim/WmiEventSink_test.go
@@ -14,22 +14,22 @@ type testCallbackContext struct {
 	completed chan bool
 }
 
-func onObjectReady(context interface{}) {
+func onObjectReady(context interface{}, wmiInstances []*WmiInstance) {
 	t := context.(*testCallbackContext)
 	t.completed <- true
 }
 
-func onCompleted(context interface{}) {
+func onCompleted(context interface{}, wmiInstances []*WmiInstance) {
 	t := context.(*testCallbackContext)
 	t.completed <- true
 }
 
-func onProgress(context interface{}) {
+func onProgress(context interface{}, wmiInstances []*WmiInstance) {
 	t := context.(*testCallbackContext)
 	t.completed <- true
 }
 
-func onObjectPut(context interface{}) {
+func onObjectPut(context interface{}, wmiInstances []*WmiInstance) {
 	t := context.(*testCallbackContext)
 	t.completed <- true
 }
@@ -57,7 +57,7 @@ func Test_WmiAsyncEvents(t *testing.T) {
 		test:      t,
 		completed: make(chan bool),
 	}
-	eventSink, err := CreateWmiEventSink(&context, onObjectReady, onCompleted, onProgress, onObjectPut)
+	eventSink, err := CreateWmiEventSink(session, &context, onObjectReady, onCompleted, onProgress, onObjectPut)
 	if err != nil {
 		t.Errorf("CreateWmiEventSink failed with error '%v'", err)
 		return

--- a/go/cim/WmiSynchronousEvents.go
+++ b/go/cim/WmiSynchronousEvents.go
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-// This class wraps a typicaly SWbemSink object. Its implementation is based on the
-// Documentation: https://docs.microsoft.com/en-us/windows/win32/wmisdk/receiving-synchronous-and-semisynchronous-event-notifications
+// This class wraps a typicaly SWbemEventSource object as returned by SWbemServices.ExecNotificationQuery. Its implementation is based on the
+// Documentations:
+//   https://docs.microsoft.com/en-us/windows/win32/wmisdk/receiving-synchronous-and-semisynchronous-event-notifications
+//   https://docs.microsoft.com/en-us/windows/win32/wmisdk/swbemservices-execnotificationquery
+//   https://docs.microsoft.com/en-us/windows/win32/wmisdk/swbemeventsource
 
 package cim
 


### PR DESCRIPTION
Improving the async WMI model to expose parameters to the callbacks
- Added support for callback parameters
- Fixed up a few documentation pointers

Tests run:
GOOS=windows GO111MODULE=on  GOARCH=amd64 go test -v ./go/...
=== RUN   Test_WmiClass
--- PASS: Test_WmiClass (0.18s)
=== RUN   Test_WmiAsyncEvents
--- PASS: Test_WmiAsyncEvents (0.79s)
=== RUN   Test_WmiInstance
--- PASS: Test_WmiInstance (0.57s)
=== RUN   Test_NewObjects
--- PASS: Test_NewObjects (0.04s)
=== RUN   Test_WmiSynchronousEvents
--- PASS: Test_WmiSynchronousEvents (0.69s)
PASS
ok      github.com/microsoft/wmi/go/cim 3.049s
?       github.com/microsoft/wmi/go/wmi [no test files]