### PR TITLE
Fixing a memory leak in the WMI query code

### DIFF
--- a/pkg/wmiinstance/WmiInstance.go
+++ b/pkg/wmiinstance/WmiInstance.go
@@ -373,5 +373,6 @@ func CloseAllInstances(instances []*WmiInstance) {
 
 // Dispose
 func (c *WmiInstance) Close() error {
+	c.instance.Release()
 	return c.instanceVar.Clear()
 }

--- a/pkg/wmiinstance/WmiSession.go
+++ b/pkg/wmiinstance/WmiSession.go
@@ -205,7 +205,6 @@ func (c *WmiSession) EnumerateInstances(className string) ([]*WmiInstance, error
 
 // QueryInstances
 func (c *WmiSession) QueryInstances(queryExpression string) ([]*WmiInstance, error) {
-	fmt.Printf("QueryInstances %s", queryExpression)
 	enum, err := c.PerformRawQuery(queryExpression)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixing a memory leak in the WMI query code
- Fixed the leak
- Removing an unnecessary printf statement