### PR TITLE
Using Syscall6/Syscall9 instead of Call

### DIFF
--- a/pkg/wmiinstance/WmiHelper.go
+++ b/pkg/wmiinstance/WmiHelper.go
@@ -5,6 +5,7 @@ package cim
 
 import (
 	"reflect"
+	"syscall"
 	"unsafe"
 
 	"github.com/go-ole/go-ole"
@@ -187,14 +188,14 @@ func FindStringInSlice(stringList []string, value string) (int, bool) {
 //
 // This function appears to block. PeekMessage does not block.
 func PeekMessage(msg *ole.Msg, hwnd uint32, MsgFilterMin uint32, MsgFilterMax uint32, RemoveMsg RemoveMessageFlags) (ret bool, err error) {
-	r0, _, err := procPeekMessageW.Call(uintptr(unsafe.Pointer(msg)), uintptr(hwnd), uintptr(MsgFilterMin), uintptr(MsgFilterMax), uintptr(RemoveMsg))
+	r0, _, err := syscall.Syscall6(procPeekMessageW.Addr(), 5, uintptr(unsafe.Pointer(msg)), uintptr(hwnd), uintptr(MsgFilterMin), uintptr(MsgFilterMax), uintptr(RemoveMsg), 0)
 	ret = bool(r0 > 0)
 	return
 }
 
 func CoInitializeSecurity(authLevel RpcAuthenticationLevel, impLevel RpcImpersonationLevel) (err error) {
 	// https://docs.microsoft.com/en-us/windows/win32/wmisdk/setting-the-default-process-security-level-using-c-
-	hr, _, _ := procCoInitializeSecurity.Call(uintptr(0), ^uintptr(0), uintptr(0), uintptr(0), uintptr(authLevel), uintptr(impLevel), uintptr(0), uintptr(EOAC_NONE), uintptr(0))
+	hr, _, _ := syscall.Syscall9(procCoInitializeSecurity.Addr(), 9, uintptr(0), ^uintptr(0), uintptr(0), uintptr(0), uintptr(authLevel), uintptr(impLevel), uintptr(0), uintptr(EOAC_NONE), uintptr(0))
 	if hr != 0 {
 		err = ole.NewError(hr)
 	}

--- a/pkg/wmiinstance/WmiInstance_test.go
+++ b/pkg/wmiinstance/WmiInstance_test.go
@@ -188,21 +188,21 @@ func Test_WmiInstance(t *testing.T) {
 		return
 	}
 
-	relatedInstances, err := systemIdleProcess.GetRelated("Win32_ComputerSystem")
+	relatedInstances, err := systemIdleProcess.GetAllRelated("Win32_ComputerSystem")
 	if err != nil {
-		t.Errorf("systemIdleProcess.GetRelated failed with error %v", err)
+		t.Errorf("systemIdleProcess.GetAllRelated failed with error %v", err)
 		return
 	}
 	defer CloseAllInstances(relatedInstances)
 
 	if len(relatedInstances) < 1 {
-		t.Errorf("systemIdleProcess.GetRelated didn't find any related Win32_ComputerSystem instances of Win32_Process")
+		t.Errorf("systemIdleProcess.GetAllRelated didn't find any related Win32_ComputerSystem instances of Win32_Process")
 		return
 	}
 
 	for _, relatedInstance := range relatedInstances {
 		if relatedInstance.GetClassName() != "Win32_ComputerSystem" {
-			t.Errorf("systemIdleProcess.GetRelated didn't find any related instances of Win32_ComputerSystem")
+			t.Errorf("systemIdleProcess.GetAllRelated didn't find any related instances of Win32_ComputerSystem")
 			return
 		}
 	}

--- a/pkg/wmiinstance/WmiSessionManager.go
+++ b/pkg/wmiinstance/WmiSessionManager.go
@@ -5,6 +5,7 @@ package cim
 
 import (
 	"errors"
+	"fmt"
 
 	ole "github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
@@ -50,7 +51,7 @@ func (c *WmiSessionManager) init() error {
 
 		// Note: RPC_E_TOO_LATE means we have already initialized security.
 		if oleCode != ole.S_OK && oleCode != S_FALSE && oleCode != uintptr(RPC_E_TOO_LATE) {
-			panic("Couldn't initialize COM/DCOM security")
+			panic(fmt.Sprintf("Couldn't initialize COM/DCOM security. Error: [%v]", err))
 		}
 	}
 


### PR DESCRIPTION
Using Syscall6/Syscall9 instead of Call
- Fixed syscall to use Syscall6/Syscall9
- Fixed the tests to make sure they build and pass
- Improved error logging when COM/DCOM cannot be initialized

Tested:
go test -v
=== RUN   Test_WmiClass
--- PASS: Test_WmiClass (0.16s)
=== RUN   Test_WmiAsyncEvents
--- PASS: Test_WmiAsyncEvents (0.73s)
=== RUN   Test_WmiInstance
--- PASS: Test_WmiInstance (0.36s)
=== RUN   Test_NewObjects
--- PASS: Test_NewObjects (0.04s)
=== RUN   Test_WmiSynchronousEvents
--- PASS: Test_WmiSynchronousEvents (0.68s)
PASS
ok      github.com/microsoft/wmi/pkg/wmiinstance        2.356s