### PR TITLE
Fixing an issue where CIM_ConcreteJob would timeout instead of returning an error on failure

### DIFF
--- a/server2019/root/hypervcluster/v2/CIM_ConcreteJob.go
+++ b/server2019/root/hypervcluster/v2/CIM_ConcreteJob.go
@@ -79,13 +79,10 @@ func (instance *CIM_ConcreteJob) GetPropertyJobState() (value ConcreteJob_JobSta
 	if err != nil {
 		return
 	}
-
-	valueint, ok := retValue.(int32)
+	value, ok := retValue.(ConcreteJob_JobState)
 	if !ok {
 		// TODO: Set an error
 	}
-	value = ConcreteJob_JobState(valueint)
-
 	return
 }
 

--- a/server2019/root/standardcimv2/CIM_ConcreteJob.go
+++ b/server2019/root/standardcimv2/CIM_ConcreteJob.go
@@ -67,13 +67,10 @@ func (instance *CIM_ConcreteJob) GetPropertyJobState() (value ConcreteJob_JobSta
 	if err != nil {
 		return
 	}
-
-	valueint, ok := retValue.(int32)
+	value, ok := retValue.(ConcreteJob_JobState)
 	if !ok {
 		// TODO: Set an error
 	}
-	value = ConcreteJob_JobState(valueint)
-
 	return
 }
 

--- a/server2019/root/standardcimv2/mlnx/CIM_ConcreteJob.go
+++ b/server2019/root/standardcimv2/mlnx/CIM_ConcreteJob.go
@@ -67,13 +67,10 @@ func (instance *CIM_ConcreteJob) GetPropertyJobState() (value ConcreteJob_JobSta
 	if err != nil {
 		return
 	}
-
-	valueint, ok := retValue.(int32)
+	value, ok := retValue.(ConcreteJob_JobState)
 	if !ok {
 		// TODO: Set an error
 	}
-	value = ConcreteJob_JobState(valueint)
-
 	return
 }
 

--- a/server2019/root/virtualization/v2/CIM_ConcreteJob.go
+++ b/server2019/root/virtualization/v2/CIM_ConcreteJob.go
@@ -79,13 +79,10 @@ func (instance *CIM_ConcreteJob) GetPropertyJobState() (value ConcreteJob_JobSta
 	if err != nil {
 		return
 	}
-
-	valueint, ok := retValue.(int32)
+	value, ok := retValue.(ConcreteJob_JobState)
 	if !ok {
 		// TODO: Set an error
 	}
-	value = ConcreteJob_JobState(valueint)
-
 	return
 }
 


### PR DESCRIPTION
Fixing an issue where CIM_ConcreteJob would timeout instead of returning an error on failure

Note: the PR modifies auto-generated files. I am working with Madhan to do the proper auto-generation tooling fix here.