### PR TITLE
Add command to restore VM

### DIFF
--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -227,6 +227,15 @@ func (vm *VirtualMachine) Resume() error {
 	return vm.WaitForState(Running, StateChangeTimeoutSeconds)
 }
 
+// Restore Virtual Machine
+func (vm *VirtualMachine) Restore() error {
+	err := vm.ChangeState(Running, job.ConcreteJob_JobType_Restore_Virtual_Machine, -1)
+	if err != nil {
+		return err
+	}
+	return vm.WaitForState(Running, StateChangeTimeoutSeconds)
+}
+
 // Pause Virtual Machine
 func (vm *VirtualMachine) Pause() error {
 	err := vm.ChangeState(Paused, job.ConcreteJob_JobType_Pause_Virtual_Machine, -1)

--- a/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
@@ -131,6 +131,23 @@ func TestVirtualMachineResume(t *testing.T) {
 	}
 }
 
+func TestVirtualMachineRestore(t *testing.T) {
+	vm, err := GetVirtualMachineByVMName(whost, "test")
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer vm.Close()
+
+	err = vm.Save()
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	err = vm.Restore()
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+}
+
 func TestGetVirtualMachineSetting(t *testing.T) {
 	vm, err := GetVirtualMachineByVMName(whost, "test")
 	if err != nil {


### PR DESCRIPTION
Addressing a small bug where the expected jobtype for resuming a saved VM is different from the performed jobtype. 