### PR TITLE
Shutdown running Gen 1 VM during DVD drive attachment

### DIFF
--- a/pkg/virtualization/core/service/dvddrive.go
+++ b/pkg/virtualization/core/service/dvddrive.go
@@ -106,6 +106,22 @@ func (vmms *VirtualSystemManagementService) RemoveISODisk(ld *disk.LogicalDisk) 
 }
 
 func (vmms *VirtualSystemManagementService) AddDvdDrive(vm *virtualsystem.VirtualMachine) (dvd *drive.DvdDrive, err error) {
+	vmGeneration, err := vm.GetVirtualMachineGeneration()
+	if err != nil {
+		return
+	}
+
+	vmState, err := vm.State()
+	if err != nil {
+		return
+	}
+
+	// DVD drives which we add to gen 1 VMs via the IDE controller cannot be hot added.  The machine must be stopped first.
+	if vmGeneration == virtualsystem.HyperVGeneration_V1 && vmState == virtualsystem.Running {
+		vm.Stop(false)
+		defer vm.Start()
+	}
+
 	// Add the dvd drive
 	tmp, err := vm.NewDvdDrive()
 	if err != nil {


### PR DESCRIPTION
Users need to run below steps to enable guest management for Day2 VMs:
1. Mount the ISO that we embed bootstrapping scripts into and attach it to the VM as a DVD drive (run az CLI).
2. Enable the guest agent on the VM (log in the VM and run the script).
3. Enable guest management (run az CLI).
 
The issue we hit is during step 1 - we always attached DVD drives to Gen 1 VMs via the IDE controller. This blocked us on day 2 operations because hot adding a DVD drive to the IDE controller of a Gen 1 VM is not supported.
 
The initial fix was to standardize the ISO attachment process across gen1 VMs and gen2 VMs so the ISO can be attached to the SCSI controller for all VMs while the VM is running. However, the gate caught a regression - the disk attachment to the SCSI controller failed in a test that ran on a machine with an older OS and VMMS version. We got information from Hyper-V team that this feature has limited support but is not yet publicly available, and they advised us to file dependency items.
 
This fix offers an alternative workaround by shutting down the Gen1 VM during the ISO attachment and restarting it once the process is complete.