### PR TITLE
Changes to support new VM Security Type

### DIFF
--- a/pkg/virtualization/constant/constant.go
+++ b/pkg/virtualization/constant/constant.go
@@ -10,3 +10,11 @@ const (
 	LinuxSecureBootTemplateGUID   SecureBootTemplateGUID = "272e7447-90a4-4563-a4b9-8e4ab00526ce"
 	OSSSecureBootTemplateGUID     SecureBootTemplateGUID = "4292ae2b-ee2c-42b5-a969-dd8f8689f6f3"
 )
+
+type ResourceSubType string
+
+const (
+	SyntheticMouseSubtype    ResourceSubType = "Microsoft:Hyper-V:Synthetic Mouse"
+	SyntheticKeyboardSubtype ResourceSubType = "Microsoft:Hyper-V:Synthetic Keyboard"
+	SyntheticDisplaySubtype  ResourceSubType = "Microsoft:Hyper-V:Synthetic Display Controller"
+)

--- a/pkg/virtualization/core/service/virtualmachine.go
+++ b/pkg/virtualization/core/service/virtualmachine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/wmi/pkg/base/query"
 	"github.com/microsoft/wmi/pkg/constant"
 	"github.com/microsoft/wmi/pkg/errors"
+	virtconstant "github.com/microsoft/wmi/pkg/virtualization/constant"
 	"github.com/microsoft/wmi/pkg/virtualization/core/memory"
 	"github.com/microsoft/wmi/pkg/virtualization/core/processor"
 	"github.com/microsoft/wmi/pkg/virtualization/core/resource/resourceallocation"
@@ -276,23 +277,18 @@ func (vmms *VirtualSystemManagementService) SetMemoryMB(vm *virtualsystem.Virtua
 // Re-implementation of Disable-VMConsoleSupport Cmdlet
 // Removes the Synthetic Mouse, Synthetic Keyboard, and Synthetic Display devices from a VM
 func (vmms *VirtualSystemManagementService) RemoveHIDDevices(vm *virtualsystem.VirtualMachine) (err error) {
-	// ResourceSubType consts. Note: Cannot query based on ResourceType because Mouse and Keyboard share ResourceType: 13
-	const SYNTHETIC_MOUSE_SUBTYPE = "Microsoft:Hyper-V:Synthetic Mouse"
-	const SYNTHETIC_KEYBOARD_SUBTYPE = "Microsoft:Hyper-V:Synthetic Keyboard"
-	const SYNTHETIC_DISPLAY_SUBTYPE = "Microsoft:Hyper-V:Synthetic Display Controller"
-
 	// Get the RASD objects representing the devices. If there are multiple RASD for a device type, will remove the first occurence
-	syntheticMouse, err1 := vm.GetResourceAllocationSettingDataBySubType(SYNTHETIC_MOUSE_SUBTYPE)
+	syntheticMouse, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticMouseSubtype)
 	if err1 == nil { // Don't error if failing to get the device. Matches behavior of Disable-VMConsoleSupport
 		defer syntheticMouse.Close()
 		vmms.RemoveVirtualSystemResource(syntheticMouse, -1)
 	}
-	syntheticKeyboard, err1 := vm.GetResourceAllocationSettingDataBySubType(SYNTHETIC_KEYBOARD_SUBTYPE)
+	syntheticKeyboard, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticKeyboardSubtype)
 	if err1 == nil {
 		defer syntheticKeyboard.Close()
 		vmms.RemoveVirtualSystemResource(syntheticKeyboard, -1)
 	}
-	syntheticDisplay, err1 := vm.GetResourceAllocationSettingDataBySubType(SYNTHETIC_DISPLAY_SUBTYPE)
+	syntheticDisplay, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticDisplaySubtype)
 	if err1 == nil {
 		defer syntheticDisplay.Close()
 		vmms.RemoveVirtualSystemResource(syntheticDisplay, -1)

--- a/pkg/virtualization/core/service/virtualmachine.go
+++ b/pkg/virtualization/core/service/virtualmachine.go
@@ -282,16 +282,22 @@ func (vmms *VirtualSystemManagementService) RemoveHIDDevices(vm *virtualsystem.V
 	if err1 == nil { // Don't error if failing to get the device. Matches behavior of Disable-VMConsoleSupport
 		defer syntheticMouse.Close()
 		vmms.RemoveVirtualSystemResource(syntheticMouse, -1)
+	} else {
+		log.Printf("Removing synthetic mouse failed with [%v]", err1)
 	}
 	syntheticKeyboard, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticKeyboardSubtype)
 	if err1 == nil {
 		defer syntheticKeyboard.Close()
 		vmms.RemoveVirtualSystemResource(syntheticKeyboard, -1)
+	} else {
+		log.Printf("Removing synthetic keyboard failed with [%v]", err1)
 	}
 	syntheticDisplay, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticDisplaySubtype)
 	if err1 == nil {
 		defer syntheticDisplay.Close()
 		vmms.RemoveVirtualSystemResource(syntheticDisplay, -1)
+	} else {
+		log.Printf("Removing synthetic display failed with [%v]", err1)
 	}
 
 	return

--- a/pkg/virtualization/core/service/virtualmachine.go
+++ b/pkg/virtualization/core/service/virtualmachine.go
@@ -281,23 +281,32 @@ func (vmms *VirtualSystemManagementService) RemoveHIDDevices(vm *virtualsystem.V
 	syntheticMouse, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticMouseSubtype)
 	if err1 == nil { // Don't error if failing to get the device. Matches behavior of Disable-VMConsoleSupport
 		defer syntheticMouse.Close()
-		vmms.RemoveVirtualSystemResource(syntheticMouse, -1)
+		err1 = vmms.RemoveVirtualSystemResource(syntheticMouse, -1)
+		if err1 != nil {
+			log.Printf("Removing synthetic mouse failed with [%v]", err1)
+		}
 	} else {
-		log.Printf("Removing synthetic mouse failed with [%v]", err1)
+		log.Printf("Getting synthetic mouse failed with [%v]", err1)
 	}
 	syntheticKeyboard, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticKeyboardSubtype)
 	if err1 == nil {
 		defer syntheticKeyboard.Close()
-		vmms.RemoveVirtualSystemResource(syntheticKeyboard, -1)
+		err1 = vmms.RemoveVirtualSystemResource(syntheticKeyboard, -1)
+		if err1 != nil {
+			log.Printf("Removing synthetic keyboard failed with [%v]", err1)
+		}
 	} else {
-		log.Printf("Removing synthetic keyboard failed with [%v]", err1)
+		log.Printf("Getting synthetic keyboard failed with [%v]", err1)
 	}
 	syntheticDisplay, err1 := vm.GetResourceAllocationSettingDataBySubType(virtconstant.SyntheticDisplaySubtype)
 	if err1 == nil {
 		defer syntheticDisplay.Close()
-		vmms.RemoveVirtualSystemResource(syntheticDisplay, -1)
+		err1 = vmms.RemoveVirtualSystemResource(syntheticDisplay, -1)
+		if err1 != nil {
+			log.Printf("Removing synthetic display failed with [%v]", err1)
+		}
 	} else {
-		log.Printf("Removing synthetic display failed with [%v]", err1)
+		log.Printf("Getting synthetic display failed with [%v]", err1)
 	}
 
 	return

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -96,6 +96,14 @@ const (
 	HyperVGeneration_V2 = "Microsoft:Hyper-V:SubType:2"
 )
 
+type GuestStateIsolationMode uint16
+
+const (
+	Default             GuestStateIsolationMode = 0
+	NoPersistentSecrets GuestStateIsolationMode = 1
+	NoManagementVtl     GuestStateIsolationMode = 2
+)
+
 // NewVirtualMachine
 func NewVirtualMachine(instance *wmi.WmiInstance) (*VirtualMachine, error) {
 	wmivm, err := v2.NewMsvm_ComputerSystemEx1(instance)

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -16,6 +16,7 @@ import (
 
 	"reflect"
 
+	virtconstant "github.com/microsoft/wmi/pkg/virtualization/constant"
 	"github.com/microsoft/wmi/pkg/virtualization/core/gpu"
 	job "github.com/microsoft/wmi/pkg/virtualization/core/job"
 	"github.com/microsoft/wmi/pkg/virtualization/core/memory"
@@ -891,7 +892,7 @@ func (vm *VirtualMachine) GetResourceAllocationSettingData(rtype v2.ResourcePool
 	return
 }
 
-func (vm *VirtualMachine) GetResourceAllocationSettingDataBySubType(resourceSubType string) (col *v2.CIM_ResourceAllocationSettingData, err error) {
+func (vm *VirtualMachine) GetResourceAllocationSettingDataBySubType(resourceSubType virtconstant.ResourceSubType) (col *v2.CIM_ResourceAllocationSettingData, err error) {
 	settings, err := vm.GetVirtualSystemSettingData()
 	if err != nil {
 		return
@@ -916,7 +917,7 @@ func (vm *VirtualMachine) GetResourceAllocationSettingDataBySubType(resourceSubT
 			continue
 		}
 
-		if resourceSubType == sourceResourceSubType {
+		if string(resourceSubType) == sourceResourceSubType {
 			instance, err1 := rasd.Clone()
 			if err1 != nil {
 				err = err1

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -925,6 +925,7 @@ func (vm *VirtualMachine) GetResourceAllocationSettingDataBySubType(resourceSubT
 			}
 			col, err1 = v2.NewCIM_ResourceAllocationSettingDataEx1(instance)
 			if err1 != nil {
+				instance.Close()
 				err = err1
 				return
 			}

--- a/pkg/virtualization/core/virtualsystem/virtualsystemsettingdata.go
+++ b/pkg/virtualization/core/virtualsystem/virtualsystemsettingdata.go
@@ -19,7 +19,7 @@ import (
 	"github.com/microsoft/wmi/pkg/virtualization/core/storage/disk"
 	na "github.com/microsoft/wmi/pkg/virtualization/network/virtualnetworkadapter"
 	wmi "github.com/microsoft/wmi/pkg/wmiinstance"
-	"github.com/microsoft/wmi/server2019/root/virtualization/v2"
+	v2 "github.com/microsoft/wmi/server2019/root/virtualization/v2"
 )
 
 type VirtualSystemSettingData struct {


### PR DESCRIPTION
Additions:

- `RemoveHIDDevices` function: removes the Synthetic Keyboard, Synthetic Mouse, and Synthetic Display Controller devices from a VM
- `GetResourceAllocationSettingDataBySubType` function: adds the ability to retrieve CIM_RASD devices by `ResourceSubType` because the existing `GetResourceAllocationSettingData` queries by `ResourceType`, which doesn't work for these devices