### PR TITLE
Add a wrapper for CompactDisk of a VHD

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -15,3 +15,13 @@ const (
 const (
 	HostName string = "localhost"
 )
+
+type VirtualHardDiskCompactMode int
+
+const (
+	VirtualHardDiskCompactModeFull       VirtualHardDiskCompactMode = 0
+	VirtualHardDiskCompactModeQuick      VirtualHardDiskCompactMode = 1
+	VirtualHardDiskCompactModeRetrim     VirtualHardDiskCompactMode = 2
+	VirtualHardDiskCompactModePretrimmed VirtualHardDiskCompactMode = 3
+	VirtualHardDiskCompactModePrezeroed  VirtualHardDiskCompactMode = 4
+)


### PR DESCRIPTION
I added a wrapper methods for `CompactVirtualHardDisk`.
As this process can take a bit longer, I created two wrappers:
- `CompactDiskAndWait` which calls compact and waits until it is finished
- `CompactDisk` which returns the created job object where the caller is responsible for closing the job object and waiting until it is finished. This has the benefit that the caller can for example print out a progress with something like:
```go
job, err := mgmt.CompactDisk(diskPath, constant.VirtualHardDiskCompactModeFull)
if err != nil {
	return err
}
defer job.Close()
for !job.IsComplete() {
	fmt.Println(job.PercentComplete())
	time.Sleep(100 * time.Millisecond)
}
```

I also added a constant for the various compact modes.