### PR TITLE
Clean up seed ISO image attached to Arc VMs

### DIFF
--- a/pkg/virtualization/core/service/dvddrive.go
+++ b/pkg/virtualization/core/service/dvddrive.go
@@ -84,48 +84,6 @@ func (vmms *VirtualSystemManagementService) AddISODisk(vm *virtualsystem.Virtual
 
 }
 
-func (vmms *VirtualSystemManagementService) GetISODisk(vm *virtualsystem.VirtualMachine, isoPath string) (ld *disk.LogicalDisk, err error) {
-	// col, err := vm.GetDvdDrives()
-	// if err != nil {
-	// 	return
-	// }
-	// defer col.Close()
-
-	// TODO: probably put this find functionality somewhere else
-	// for _, inst := range col {
-	// 	dvddrive, err := drive.NewDvdDrive(inst)
-	// 	if err != nil {
-	// 		return nil, err
-	// }
-	// Get the logical disk
-	// ld, err := disk.GetLogicalDiskByHostResource(vm, isoPath)
-	// if err != nil {
-	// 	return nil
-	// }
-	return nil, errors.NotImplemented
-}
-
-func (vmms *VirtualSystemManagementService) RemoveISODisk(ld *disk.LogicalDisk) (err error) {
-	dvddrive, err := ld.GetDrive()
-	if err != nil {
-		return
-	}
-	defer dvddrive.Close()
-
-	// Remove Disk
-	err1 := vmms.RemoveVirtualSystemResource(ld.CIM_ResourceAllocationSettingData, -1)
-	// Remove Drive
-	err = vmms.RemoveVirtualSystemResource(dvddrive.CIM_ResourceAllocationSettingData, -1)
-	if err != nil {
-		return
-	}
-	if err1 != nil {
-		err = err1
-		return
-	}
-	return
-}
-
 func (vmms *VirtualSystemManagementService) AddDvdDrive(vm *virtualsystem.VirtualMachine) (dvd *drive.DvdDrive, err error) {
 	// Add the dvd drive
 	tmp, err := vm.NewDvdDrive()
@@ -163,5 +121,10 @@ func (vmms *VirtualSystemManagementService) AddDvdDrive(vm *virtualsystem.Virtua
 
 func (vmms *VirtualSystemManagementService) RemoveDvdDrive(dvd *drive.DvdDrive) (err error) {
 	err = vmms.RemoveVirtualSystemResource(dvd.CIM_ResourceAllocationSettingData, -1)
+	return
+}
+
+func (vmms *VirtualSystemManagementService) RemoveDvdDisk(dvddisk *disk.LogicalDisk) (err error) {
+	err = vmms.RemoveVirtualSystemResource(dvddisk.CIM_ResourceAllocationSettingData, -1)
 	return
 }

--- a/pkg/virtualization/core/service/dvddrive.go
+++ b/pkg/virtualization/core/service/dvddrive.go
@@ -84,6 +84,27 @@ func (vmms *VirtualSystemManagementService) AddISODisk(vm *virtualsystem.Virtual
 
 }
 
+func (vmms *VirtualSystemManagementService) RemoveISODisk(ld *disk.LogicalDisk) (err error) {
+	dvddrive, err := ld.GetDrive()
+	if err != nil {
+		return
+	}
+	defer dvddrive.Close()
+
+	// Remove Disk
+	err1 := vmms.RemoveVirtualSystemResource(ld.CIM_ResourceAllocationSettingData, -1)
+	// Remove Drive
+	err = vmms.RemoveVirtualSystemResource(dvddrive.CIM_ResourceAllocationSettingData, -1)
+	if err != nil {
+		return
+	}
+	if err1 != nil {
+		err = err1
+		return
+	}
+	return
+}
+
 func (vmms *VirtualSystemManagementService) AddDvdDrive(vm *virtualsystem.VirtualMachine) (dvd *drive.DvdDrive, err error) {
 	// Add the dvd drive
 	tmp, err := vm.NewDvdDrive()

--- a/pkg/virtualization/core/service/dvddrive.go
+++ b/pkg/virtualization/core/service/dvddrive.go
@@ -84,6 +84,27 @@ func (vmms *VirtualSystemManagementService) AddISODisk(vm *virtualsystem.Virtual
 
 }
 
+func (vmms *VirtualSystemManagementService) GetISODisk(vm *virtualsystem.VirtualMachine, isoPath string) (ld *disk.LogicalDisk, err error) {
+	// col, err := vm.GetDvdDrives()
+	// if err != nil {
+	// 	return
+	// }
+	// defer col.Close()
+
+	// TODO: probably put this find functionality somewhere else
+	// for _, inst := range col {
+	// 	dvddrive, err := drive.NewDvdDrive(inst)
+	// 	if err != nil {
+	// 		return nil, err
+	// }
+	// Get the logical disk
+	// ld, err := disk.GetLogicalDiskByHostResource(vm, isoPath)
+	// if err != nil {
+	// 	return nil
+	// }
+	return nil, errors.NotImplemented
+}
+
 func (vmms *VirtualSystemManagementService) RemoveISODisk(ld *disk.LogicalDisk) (err error) {
 	dvddrive, err := ld.GetDrive()
 	if err != nil {

--- a/pkg/virtualization/core/storage/disk/logicaldisk.go
+++ b/pkg/virtualization/core/storage/disk/logicaldisk.go
@@ -6,6 +6,7 @@ package disk
 import (
 	"github.com/microsoft/wmi/pkg/base/instance"
 	"github.com/microsoft/wmi/pkg/constant"
+	"github.com/microsoft/wmi/pkg/errors"
 	"github.com/microsoft/wmi/pkg/virtualization/core/resource/resourceallocation"
 	wmi "github.com/microsoft/wmi/pkg/wmiinstance"
 	v2 "github.com/microsoft/wmi/server2019/root/virtualization/v2"
@@ -34,4 +35,15 @@ func (ld *LogicalDisk) GetDrive() (*resourceallocation.ResourceAllocationSetting
 		return nil, err
 	}
 	return resourceallocation.NewResourceAllocationSettingData(inst)
+}
+
+func (ld *LogicalDisk) GetPath() (string, error) {
+	value, err := ld.GetProperty("HostResource")
+	if err != nil {
+		return "", err
+	}
+	for _, hr := range value.([]interface{}) {
+		return hr.(string), nil
+	}
+	return "", errors.Wrapf(errors.NotFound, "")
 }

--- a/pkg/virtualization/core/storage/disk/logicaldisk.go
+++ b/pkg/virtualization/core/storage/disk/logicaldisk.go
@@ -6,7 +6,6 @@ package disk
 import (
 	"github.com/microsoft/wmi/pkg/base/instance"
 	"github.com/microsoft/wmi/pkg/constant"
-	"github.com/microsoft/wmi/pkg/errors"
 	"github.com/microsoft/wmi/pkg/virtualization/core/resource/resourceallocation"
 	wmi "github.com/microsoft/wmi/pkg/wmiinstance"
 	v2 "github.com/microsoft/wmi/server2019/root/virtualization/v2"
@@ -35,15 +34,4 @@ func (ld *LogicalDisk) GetDrive() (*resourceallocation.ResourceAllocationSetting
 		return nil, err
 	}
 	return resourceallocation.NewResourceAllocationSettingData(inst)
-}
-
-func (ld *LogicalDisk) GetPath() (string, error) {
-	value, err := ld.GetProperty("HostResource")
-	if err != nil {
-		return "", err
-	}
-	for _, hr := range value.([]interface{}) {
-		return hr.(string), nil
-	}
-	return "", errors.Wrapf(errors.NotFound, "")
 }

--- a/pkg/virtualization/core/storage/drive/dvddrive.go
+++ b/pkg/virtualization/core/storage/drive/dvddrive.go
@@ -19,27 +19,6 @@ func NewDvdDrive(instance *wmi.WmiInstance) (*DvdDrive, error) {
 	return &DvdDrive{wmivm}, nil
 }
 
-type DvdDriveCollection []*DvdDrive
-
-func NewDvdDriveCollection(instances []*wmi.WmiInstance) (col DvdDriveCollection, err error) {
-	for _, inst := range instances {
-		na, err1 := NewDvdDrive(inst)
-		if err1 != nil {
-			err = err1
-			return
-		}
-		col = append(col, na)
-	}
-	return
-}
-
-func Close(vms *DvdDriveCollection) (err error) {
-	for _, value := range *vms {
-		value.Close()
-	}
-	return nil
-}
-
 func GetRelatedStorageAllocationSettingData(instance *wmi.WmiInstance) (value *wmi.WmiInstance, err error) {
 	return instance.GetRelated("Msvm_StorageAllocationSettingData")
 }

--- a/pkg/virtualization/core/storage/drive/dvddrive.go
+++ b/pkg/virtualization/core/storage/drive/dvddrive.go
@@ -18,3 +18,28 @@ func NewDvdDrive(instance *wmi.WmiInstance) (*DvdDrive, error) {
 	}
 	return &DvdDrive{wmivm}, nil
 }
+
+type DvdDriveCollection []*DvdDrive
+
+func NewDvdDriveCollection(instances []*wmi.WmiInstance) (col DvdDriveCollection, err error) {
+	for _, inst := range instances {
+		na, err1 := NewDvdDrive(inst)
+		if err1 != nil {
+			err = err1
+			return
+		}
+		col = append(col, na)
+	}
+	return
+}
+
+func Close(vms *DvdDriveCollection) (err error) {
+	for _, value := range *vms {
+		value.Close()
+	}
+	return nil
+}
+
+func GetRelatedStorageAllocationSettingData(instance *wmi.WmiInstance) (value *wmi.WmiInstance, err error) {
+	return instance.GetRelated("Msvm_StorageAllocationSettingData")
+}

--- a/pkg/virtualization/core/storage/drive/dvddrivecollection.go
+++ b/pkg/virtualization/core/storage/drive/dvddrivecollection.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package drive
+
+import (
+	wmi "github.com/microsoft/wmi/pkg/wmiinstance"
+)
+
+type DvdDriveCollection []*DvdDrive
+
+func NewDvdDriveCollection(instances []*wmi.WmiInstance) (col DvdDriveCollection, err error) {
+	for _, inst := range instances {
+		na, err1 := NewDvdDrive(inst)
+		if err1 != nil {
+			err = err1
+			return
+		}
+		col = append(col, na)
+	}
+	return
+}
+
+func (dvdcol *DvdDriveCollection) Close() (err error) {
+	for _, value := range *dvdcol {
+		value.Close()
+	}
+	return nil
+}

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -762,6 +762,11 @@ func (vm *VirtualMachine) GetVirtualHardDrives() (col resourceallocation.Resourc
 	return
 }
 
+func (vm *VirtualMachine) GetDvdDrives() (col resourceallocation.ResourceAllocationSettingDataCollection, err error) {
+	col, err = vm.GetResourceAllocationSettingData(v2.ResourcePool_ResourceType_DVD_drive)
+	return
+}
+
 func (vm *VirtualMachine) GetVirtualHardDiskByLocation(controllerNumber, controllerLocation int) (vhd *disk.VirtualHardDisk, err error) {
 	col, err := vm.GetVirtualHardDisks()
 	if err != nil {

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -772,14 +772,14 @@ func (vm *VirtualMachine) GetDvdDrives() (col drive.DvdDriveCollection, err erro
 	return settings.GetVirtualDvdDrives()
 }
 
-func (vm *VirtualMachine) GetDvdConfigByIsoPath(isoPath string) (dvd *drive.DvdDrive, diskdvd *disk.LogicalDisk, err error) {
-	col, err := vm.GetDvdDrives()
+func (vm *VirtualMachine) GetDvdDriveAndLogicalDiskByIsoPath(isoPath string) (dvd *drive.DvdDrive, diskdvd *disk.LogicalDisk, err error) {
+	dvdCol, err := vm.GetDvdDrives()
 	if err != nil {
 		return
 	}
-	defer drive.Close(&col)
+	defer dvdCol.Close()
 
-	for _, inst := range col {
+	for _, inst := range dvdCol {
 		dvddisk, err1 := drive.GetRelatedStorageAllocationSettingData(inst.WmiInstance)
 		if err1 != nil {
 			// Missing related storage allocation data is benign

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -5,6 +5,7 @@ package virtualsystem
 
 import (
 	"fmt"
+	"path/filepath"
 
 	//"log"
 	"time"
@@ -807,7 +808,7 @@ func (vm *VirtualMachine) GetDvdConfigByIsoPath(isoPath string) (dvd *drive.DvdD
 			dvdPath = string(valuetmp)
 		}
 
-		if dvdPath != isoPath {
+		if filepath.Clean(dvdPath) != filepath.Clean(isoPath) {
 			continue
 		}
 

--- a/pkg/virtualization/core/virtualsystem/virtualmachinesetting_test.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachinesetting_test.go
@@ -50,3 +50,24 @@ func TestGetVirtualHardDisks(t *testing.T) {
 	defer vhds.Close()
 	t.Logf("Virtual Hard Disks Found [%d]", len(vhds))
 }
+
+func TestGetVirtualDvdDrives(t *testing.T) {
+	vm, err := GetVirtualMachineByVMName(whost, "test")
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer vm.Close()
+
+	setting, err := vm.GetVirtualSystemSettingData()
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer setting.Close()
+
+	dvds, err := setting.GetVirtualDvdDrives()
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer dvds.Close()
+	t.Logf("DVD drives Found [%d]", len(dvds))
+}

--- a/pkg/virtualization/core/virtualsystem/virtualsystemsettingdata.go
+++ b/pkg/virtualization/core/virtualsystem/virtualsystemsettingdata.go
@@ -17,6 +17,7 @@ import (
 	"github.com/microsoft/wmi/pkg/virtualization/core/pcie"
 	"github.com/microsoft/wmi/pkg/virtualization/core/processor"
 	"github.com/microsoft/wmi/pkg/virtualization/core/storage/disk"
+	"github.com/microsoft/wmi/pkg/virtualization/core/storage/drive"
 	na "github.com/microsoft/wmi/pkg/virtualization/network/virtualnetworkadapter"
 	wmi "github.com/microsoft/wmi/pkg/wmiinstance"
 	v2 "github.com/microsoft/wmi/server2019/root/virtualization/v2"
@@ -245,6 +246,21 @@ func (vm *VirtualSystemSettingData) GetVirtualHardDisks() (col disk.VirtualHardD
 	}
 
 	col, err = disk.NewVirtualHardDiskCollection(rasdcollection)
+	if err != nil {
+		rasdcollection.Close()
+	}
+	return
+}
+
+func (vm *VirtualSystemSettingData) GetVirtualDvdDrives() (col drive.DvdDriveCollection, err error) {
+	resourceType := fmt.Sprintf("%d", int32(v2.ResourceAllocationSettingData_ResourceType_DVD_drive))
+	query := query.NewWmiQuery("Cim_ResourceAllocationSettingData", "ResourceType", resourceType)
+	rasdcollection, err := instance.GetWmiInstancesFromHost(vm.GetWmiHost(), string(constant.Virtualization), query)
+	if err != nil {
+		return
+	}
+
+	col, err = drive.NewDvdDriveCollection(rasdcollection)
 	if err != nil {
 		rasdcollection.Close()
 	}


### PR DESCRIPTION
Workitem - https://msazure.visualstudio.com/One/_workitems/edit/29805309

This PR has the WMI changes for retrieving the DVD disk and DVD drive attached to an Arc VM. This code would be invoked by helper code in `moc-pkg` which would detach the seed ISO from the VM and ultimately delete it from the storage container.

Testing
---------

**1. Able to detach and delete an attached ISO file from a HyperV VM for testing purposes
2. HaaS testing - Complete (Look at images attached below)**

Linux VM before fix
![linuxvm-before](https://github.com/user-attachments/assets/732300af-f2ba-43f2-89b1-0dbf1efddd5f)

Linux VM after fix
![linuxvm-after](https://github.com/user-attachments/assets/5ba7d2f8-087f-4c81-887a-57777f4a816c)

Windows VM before fix
![windowsvm-before](https://github.com/user-attachments/assets/e378ec79-0863-49f5-bb9d-931055f3cb09)

Windows VM after fix
![windowsvm-after](https://github.com/user-attachments/assets/cd5ab3c7-f7ce-4022-a232-8dcc897bb9ca)

3. Unit test results

> **go test -v .\pkg\virtualization\core\service\... -run ^TestAddRemoveIsoDiskByPath$**
> === RUN   TestAddRemoveIsoDiskByPath
> 2024/10/18 15:38:54 [WMI] QueryInstances [SELECT * FROM Msvm_VirtualSystemManagementService]=> [1]
> 2024/10/18 15:38:54 [WMI] QueryInstanceEx [SELECT * FROM Msvm_VirtualSystemManagementService]=>[1]instances
>     virtualmachinemanagementservice_test.go:252: Found [test] VMs
> 2024/10/18 15:38:54 [WMI] QueryInstances [SELECT * FROM Cim_ResourcePool WHERE  Primordial = 'True' AND ResourceType = '6' AND ResourceSubType = 'Microsoft:Hyper-V:Synthetic SCSI Controller' ]=> [1]
> 2024/10/18 15:38:54 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:Definition\\BDE5D4D6-E450-46D2-B925-976CA3E989B4\\Default"]
> 2024/10/18 15:38:54 [WMI] - Executing Method [AddResourceSettings]
> 2024/10/18 15:38:54 [WMI] - Return [0]
> 2024/10/18 15:38:54 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:796E3843-7643-45A4-B4D8-E7A127B3BCA8\\C227D43D-FEED-4A63-AD91-2814C5B99C5F\\0"]
> 2024/10/18 15:38:54 [WMI] QueryInstances [SELECT * FROM Cim_ResourcePool WHERE  Primordial = 'True' AND ResourceType = '16' ]=> [1]
> 2024/10/18 15:38:55 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:Definition\\7951A5ED-8DC5-42D7-AA8C-9F14C54CEB84\\Default"]
> 2024/10/18 15:38:55 [WMI] - Executing Method [AddResourceSettings]
> 2024/10/18 15:38:55 [WMI] - Return [0]
> 2024/10/18 15:38:55 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:796E3843-7643-45A4-B4D8-E7A127B3BCA8\\C227D43D-FEED-4A63-AD91-2814C5B99C5F\\0\\0\\D"]
> 2024/10/18 15:38:55 [WMI] QueryInstances [SELECT * FROM Cim_ResourcePool WHERE  Primordial = 'True' AND ResourceType = '31' AND ResourceSubType = 'Microsoft:Hyper-V:Virtual Hard Disk' ]=> [1]
> 2024/10/18 15:38:55 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_StorageAllocationSettingData.InstanceID="Microsoft:Definition\\70BB60D2-A9D3-46AA-B654-3DE53004B4F8\\Default"]
> 2024/10/18 15:38:55 [WMI] - Executing Method [AddResourceSettings]
> 2024/10/18 15:38:55 [WMI] - Return [0]
> 2024/10/18 15:38:55 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_StorageAllocationSettingData.InstanceID="Microsoft:796E3843-7643-45A4-B4D8-E7A127B3BCA8\\C227D43D-FEED-4A63-AD91-2814C5B99C5F\\0\\0\\L"]
> 2024/10/18 15:38:55 [WMI] QueryInstances [SELECT * FROM Cim_ResourceAllocationSettingData WHERE  ResourceType = '16' ]=> [8]
>     virtualmachinemanagementservice_test.go:280: Obtained ISO disk [c:\test\tmp.iso] from [test]
> 2024/10/18 15:38:57 [WMI] - Executing Method [RemoveResourceSettings]
> 2024/10/18 15:38:57 [WMI] - Return [0]
> 2024/10/18 15:38:57 [WMI] - Executing Method [RemoveResourceSettings]
> 2024/10/18 15:38:57 [WMI] - Return [0]
> --- PASS: TestAddRemoveIsoDiskByPath (3.10s)
> PASS
> ok      github.com/microsoft/wmi/pkg/virtualization/core/service        3.203s
> 
> 
> **go test -v .\pkg\virtualization\core\virtualsystem\... -run TestGetVirtualDvdDrives**
> 2024/10/18 15:42:27 [WMI] QueryInstances [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=> [2]
> 2024/10/18 15:42:27 [WMI] QueryInstanceEx [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=>[2]instances
> 2024/10/18 15:42:27 [WMI] QueryInstances [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=> [2]
> 2024/10/18 15:42:27 [WMI] QueryInstanceEx [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=>[2]instances
> === RUN   TestGetVirtualDvdDrives
> 2024/10/18 15:42:27 [WMI] QueryInstances [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=> [2]
> 2024/10/18 15:42:27 [WMI] QueryInstanceEx [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=>[2]instances
> 2024/10/18 15:42:27 [WMI] QueryInstances [SELECT * FROM Cim_ResourceAllocationSettingData WHERE  ResourceType = '16' ]=> [7]
>     virtualmachinesetting_test.go:72: DVD drives Found [7]
> --- PASS: TestGetVirtualDvdDrives (0.19s)
> PASS
> ok      github.com/microsoft/wmi/pkg/virtualization/core/virtualsystem  0.849s