### PR TITLE
Address review comments for WMI PR

### DIFF
--- a/pkg/virtualization/core/service/virtualmachinemanagementservice_test.go
+++ b/pkg/virtualization/core/service/virtualmachinemanagementservice_test.go
@@ -665,6 +665,12 @@ func TestAddRemoveVirtualHardDisk(t *testing.T) {
 		t.Fatalf("Failed [%+v]", err)
 	}
 
+	vhds, err := vm.GetAttachedVirtualHardDisks()
+	if err != nil {
+		t.Fatalf("Failed [%+v]", err)
+	}
+	numVhds := len(vhds)
+
 	ims, err := service.GetImageManagementService(whost)
 	if err != nil {
 		t.Fatalf("Failed [%+v]", err)
@@ -701,6 +707,16 @@ func TestAddRemoveVirtualHardDisk(t *testing.T) {
 			t.Fatalf("Failed [%+v]", err)
 		}
 		t.Logf("ControllerNumber [%s], ControllerLocation [%s]", controllerNumber, controllerlocation)
+
+		vhds, err := vm.GetAttachedVirtualHardDisks()
+		if err != nil {
+			t.Fatalf("Failed " + err.Error())
+		}
+		if len(vhds) != (numVhds + 1) {
+			t.Fatalf("Incorrect number of VHDs retrieved from VM! Received %d expected %d", len(vhds), (numVhds + 1))
+		} else {
+			numVhds = numVhds + 1
+		}
 	}
 
 	for i := 1; i <= 4; i++ {
@@ -715,6 +731,16 @@ func TestAddRemoveVirtualHardDisk(t *testing.T) {
 			t.Fatalf("Failed [%+v]", err)
 		}
 		t.Logf("Detached vhd [%s] from [%s]", path, "test")
+
+		vhds, err := vm.GetAttachedVirtualHardDisks()
+		if err != nil {
+			t.Fatal("Failed " + err.Error())
+		}
+		if len(vhds) != (numVhds - 1) {
+			t.Fatalf("Incorrect number of VHDs retrieved from VM! Received %d expected %d", len(vhds), (numVhds + 1))
+		} else {
+			numVhds = numVhds - 1
+		}
 	}
 }
 

--- a/pkg/virtualization/core/service/virtualmachinemanagementservice_test.go
+++ b/pkg/virtualization/core/service/virtualmachinemanagementservice_test.go
@@ -648,6 +648,44 @@ func TestVirtualMachineAdapterCreationWithMacGen1(t *testing.T) {
 	}
 }
 
+func TestGetVirtualMachineNetworkAdapterByMac(t *testing.T) {
+	vmms, err := GetVirtualSystemManagementService(whost)
+	if err != nil {
+		t.Fatalf("Failed [%+v]", err)
+	}
+
+	vs, err := virtualswitch.GetVirtualSwitch(whost, "testGen1")
+	if err != nil {
+		t.Fatalf("Failed [%+v]", err)
+	}
+	defer vs.Close()
+	t.Logf("Got VirtualSwitch[%s]", "testGen1")
+
+	vm, err := vmms.GetVirtualMachineByName("testGen1")
+	if err != nil {
+		t.Fatalf("Failed [%+v]", err)
+	}
+	t.Logf("Found [%s] VMs", "testGen1")
+	defer vm.Close()
+
+	adapterName := "testadapter"
+	macAddressHyperV := "02ECC85C1122"
+	macAddress := "02:EC:C8:5C:11:22"
+	t.Logf("Adding VmNic with MAC to [%s]", "testGen1")
+	na, err := vmms.AddVirtualNetworkAdapterWithMac(vm, adapterName, macAddressHyperV)
+	if err != nil {
+		t.Fatalf("Failed [%+v]", err)
+	}
+	defer na.Close()
+
+	testna, err := vm.GetVirtualGuestNetworkAdapterConfiguration(macAddress)
+	if err != nil {
+		t.Fatalf("Failed [%+v]", err)
+	}
+	defer testna.Close()
+	t.Logf("Found Adapter [%s]", adapterName)
+}
+
 func TestAddRemoveVirtualHardDisk(t *testing.T) {
 	vmms, err := GetVirtualSystemManagementService(whost)
 	if err != nil {

--- a/pkg/virtualization/core/storage/disk/virtualharddisksettingdata.go
+++ b/pkg/virtualization/core/storage/disk/virtualharddisksettingdata.go
@@ -108,30 +108,31 @@ func GetVirtualHardDiskSettingDataFromXml(whost *host.WmiHost, xmlInstance strin
 	}
 
 	for _, property := range diskData.PROPERTY {
-		if property.NAME == "MaxInternalSize" {
+		switch property.NAME {
+		case "MaxInternalSize":
 			size, err = strconv.ParseUint(property.VALUE, 10, 64)
 			if err != nil {
 				return
 			}
-		} else if property.NAME == "BlockSize" {
+		case "BlockSize":
 			tempvar, err = strconv.ParseUint(property.VALUE, 10, 32)
 			if err != nil {
 				return
 			}
 			blockSize = uint32(tempvar)
-		} else if property.NAME == "LogicalSectorSize" {
+		case "LogicalSectorSize":
 			tempvar, err = strconv.ParseUint(property.VALUE, 10, 32)
 			if err != nil {
 				return
 			}
 			lSectorSize = uint32(tempvar)
-		} else if property.NAME == "PhysicalSectorSize" {
+		case "PhysicalSectorSize":
 			tempvar, err = strconv.ParseUint(property.VALUE, 10, 32)
 			if err != nil {
 				return
 			}
 			pSectorSize = uint32(tempvar)
-		} else if property.NAME == "Format" {
+		case "Format":
 			tempvar, err = strconv.ParseUint(property.VALUE, 10, 16)
 			if err != nil {
 				return

--- a/pkg/virtualization/core/storage/service/ImageManagementService_test.go
+++ b/pkg/virtualization/core/storage/service/ImageManagementService_test.go
@@ -35,7 +35,7 @@ func TestCreateDynamicVirtualHardDisk(t *testing.T) {
 		t.Fatal("Failed " + err.Error())
 	}
 	path := "c:\\test\\tmp.vhdx"
-	setting, err := disk.GetVirtualHardDiskSettingData(whost, path, 512, 512, 0, 1024*1024*10, true)
+	setting, err := disk.GetVirtualHardDiskSettingData(whost, path, 512, 512, 0, 1024*1024*10, true, disk.VirtualHardDiskFormat_2)
 	if err != nil {
 		t.Fatal("Failed " + err.Error())
 	}
@@ -58,7 +58,7 @@ func TestCreateStaticVirtualHardDisk(t *testing.T) {
 		t.Fatal("Failed " + err.Error())
 	}
 	path := "c:\\test\\tmp.vhdx"
-	setting, err := disk.GetVirtualHardDiskSettingData(whost, path, 512, 512, 0, 1024*1024*10, false)
+	setting, err := disk.GetVirtualHardDiskSettingData(whost, path, 512, 512, 0, 1024*1024*10, false, disk.VirtualHardDiskFormat_2)
 	if err != nil {
 		t.Fatal("Failed " + err.Error())
 	}
@@ -81,10 +81,10 @@ func TestGetVirtualHardDiskConfig(t *testing.T) {
 		t.Fatal("Failed " + err.Error())
 	}
 	path := "c:\\test\\tmp.vhdx"
-	disksize := 1024 * 1024 * 10
-	lsectorSize := 512
-	psectorSize := 512
-	setting, err := disk.GetVirtualHardDiskSettingData(whost, path, lsectorSize, psectorSize, 0, disksize, true)
+	var disksize uint64 = 1024 * 1024 * 10
+	var lsectorSize uint32 = 512
+	var psectorSize uint32 = 512
+	setting, err := disk.GetVirtualHardDiskSettingData(whost, path, lsectorSize, psectorSize, 0, disksize, true, disk.VirtualHardDiskFormat_2)
 	if err != nil {
 		t.Fatal("Failed " + err.Error())
 	}
@@ -100,15 +100,15 @@ func TestGetVirtualHardDiskConfig(t *testing.T) {
 		t.Fatal("Get vhd configuration failed " + err.Error())
 	}
 
-	if readSize != uint64(disksize) {
+	if readSize != disksize {
 		t.Fatal("Get vhd configuration size mismatch")
 	}
 
-	if readLsectorSize != uint32(lsectorSize) {
+	if readLsectorSize != lsectorSize {
 		t.Fatal("Get vhd configuration logical sector mismatch")
 	}
 
-	if readPsectorSize != uint32(psectorSize) {
+	if readPsectorSize != psectorSize {
 		t.Fatal("Get vhd configuration physical sector mismatch")
 	}
 }

--- a/pkg/virtualization/core/storage/service/ImageManagementService_test.go
+++ b/pkg/virtualization/core/storage/service/ImageManagementService_test.go
@@ -6,9 +6,10 @@ package service
 import (
 	"os"
 
+	"testing"
+
 	"github.com/microsoft/wmi/pkg/base/host"
 	_ "github.com/microsoft/wmi/pkg/base/session"
-	"testing"
 
 	"github.com/microsoft/wmi/pkg/virtualization/core/storage/disk"
 )
@@ -71,5 +72,43 @@ func TestCreateStaticVirtualHardDisk(t *testing.T) {
 	err = ims.ResizeDisk(path, 1024*1024*100)
 	if err != nil {
 		t.Fatal("Resize Failed " + err.Error())
+	}
+}
+
+func TestGetVirtualHardDiskConfig(t *testing.T) {
+	ims, err := GetImageManagementService(whost)
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	path := "c:\\test\\tmp.vhdx"
+	disksize := 1024 * 1024 * 10
+	lsectorSize := 512
+	psectorSize := 512
+	setting, err := disk.GetVirtualHardDiskSettingData(whost, path, lsectorSize, psectorSize, 0, disksize, true)
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer setting.Close()
+	err = ims.CreateDisk(setting)
+	if err != nil {
+		t.Fatal("Create Failed " + err.Error())
+	}
+	defer os.RemoveAll(path)
+
+	readSize, _, readLsectorSize, readPsectorSize, _, err := ims.GetVirtualHardDiskConfig(path)
+	if err != nil {
+		t.Fatal("Get vhd configuration failed " + err.Error())
+	}
+
+	if readSize != uint64(disksize) {
+		t.Fatal("Get vhd configuration size mismatch")
+	}
+
+	if readLsectorSize != uint32(lsectorSize) {
+		t.Fatal("Get vhd configuration logical sector mismatch")
+	}
+
+	if readPsectorSize != uint32(psectorSize) {
+		t.Fatal("Get vhd configuration physical sector mismatch")
 	}
 }

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -351,6 +351,7 @@ func (vm *VirtualMachine) GetVirtualGuestNetworkAdapterConfiguration(inputMacAdd
 	if err != nil {
 		return nil, err
 	}
+	defer allSettings.Close()
 
 	/* The input MAC address would be always in standard format (i.e aa:bb:cc:dd:ee:ff)
 	   But the address read from system would be in HyperV format (i.e AABBCCDDEEFF) */
@@ -379,10 +380,15 @@ func (vm *VirtualMachine) GetVirtualGuestNetworkAdapterConfiguration(inputMacAdd
 			if strings.EqualFold(inputMacAddressHyperV, networkAdapterMacAddress) {
 				wmiGuestConfig, err := syntheticNetworkAdapter.GetRelated("Msvm_GuestNetworkAdapterConfiguration")
 				if err != nil {
-					continue
+					return nil, err
 				}
-				guestNetworkAdapterConfiguration, _ = na.NewGuestNetworkAdapterConfiguration(wmiGuestConfig)
-				return guestNetworkAdapterConfiguration, nil
+
+				wmiGuestConfigClone, err := wmiGuestConfig.Clone()
+				if err != nil {
+					return nil, err
+				}
+
+				return na.NewGuestNetworkAdapterConfiguration(wmiGuestConfigClone)
 			}
 		}
 	}
@@ -392,14 +398,14 @@ func (vm *VirtualMachine) GetVirtualGuestNetworkAdapterConfiguration(inputMacAdd
 
 func (vm *VirtualMachine) GetSecuritySettingData() (value *MsvmSecuritySettingData, err error) {
 	inst, err := vm.GetRelated("Msvm_Tpm")
+	if err != nil {
+		return nil, err
+	}
+	defer inst.Close()
 
 	// If the TPM is not found, then it is not configured or enabled
 	if inst == nil {
 		return nil, nil
-	}
-
-	if err != nil {
-		return nil, err
 	}
 
 	tpmwmi, err := v2.NewMsvm_TPMEx1(inst)
@@ -412,7 +418,12 @@ func (vm *VirtualMachine) GetSecuritySettingData() (value *MsvmSecuritySettingDa
 		return nil, err
 	}
 
-	securitySettings, err := v2.NewMsvm_SecuritySettingDataEx1(cimSettings)
+	cimSettingsClone, err := cimSettings.Clone()
+	if err != nil {
+		return nil, err
+	}
+
+	securitySettings, err := v2.NewMsvm_SecuritySettingDataEx1(cimSettingsClone)
 	if err != nil {
 		return nil, err
 	}
@@ -420,11 +431,12 @@ func (vm *VirtualMachine) GetSecuritySettingData() (value *MsvmSecuritySettingDa
 	return &MsvmSecuritySettingData{securitySettings}, nil
 }
 
-func (vm *VirtualMachine) GetOSConfiguration() (computerName string, isWindows bool) {
+func (vm *VirtualMachine) GetOSConfiguration() (computerName string, isWindows bool, err error) {
 	inst, err := vm.GetRelated("Msvm_KvpExchangeComponent")
 	if err != nil {
 		return
 	}
+	defer inst.Close()
 
 	kvp, err := v2.NewMsvm_KvpExchangeComponentEx1(inst)
 	if err != nil {
@@ -446,11 +458,10 @@ func (vm *VirtualMachine) GetOSConfiguration() (computerName string, isWindows b
 
 		var key, value string
 		for _, property := range guestProperty.PROPERTY {
-			if property.NAME == "Name" {
+			switch property.NAME {
+			case "Name":
 				key = property.VALUE
-			}
-
-			if property.NAME == "Data" {
+			case "Data":
 				value = property.VALUE
 			}
 		}
@@ -460,8 +471,17 @@ func (vm *VirtualMachine) GetOSConfiguration() (computerName string, isWindows b
 		}
 	}
 
-	computerName = guestKvPairs["FullyQualifiedDomainName"]
-	osName := guestKvPairs["OSName"]
+	computerName, ok := guestKvPairs["FullyQualifiedDomainName"]
+	if !ok {
+		err = errors.Wrapf(errors.InvalidInput, "Unable to retrieve computer name via WMI")
+		return
+	}
+
+	osName, ok := guestKvPairs["OSName"]
+	if !ok {
+		err = errors.Wrapf(errors.InvalidInput, "Unable to retrieve operating system type via WMI")
+		return
+	}
 	if strings.Contains(strings.ToLower(osName), "window") {
 		isWindows = true
 	}

--- a/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
@@ -162,35 +162,6 @@ func TestGetVirtualMachineSetting(t *testing.T) {
 	defer setting.Close()
 }
 
-func TestGetVirtualMachineNetworkAdapterByMac(t *testing.T) {
-	vm, err := GetVirtualMachineByVMName(whost, "test")
-	if err != nil {
-		t.Fatal("Failed " + err.Error())
-	}
-	defer vm.Close()
-
-	vna, err := vm.NewSyntheticNetworkAdapter("test1-nic1")
-	if err != nil {
-		t.Fatal("Failed " + err.Error())
-	}
-	defer vna.Close()
-
-	macAddress, err := vna.GetPropertyAddress()
-	if err != nil {
-		t.Fatal("Failed to get MAC address " + err.Error())
-	}
-
-	if macAddress == "" {
-		t.Fatal("Empty MAC address for synthetic network adapter")
-	}
-	t.Logf("Added network interface with MAC %s", macAddress)
-
-	_, err = vm.GetVirtualGuestNetworkAdapterConfiguration(macAddress)
-	if err != nil {
-		t.Fatal("Failed to get guest network adapter config" + err.Error())
-	}
-}
-
 func TestGetVirtualMachineOSConfiguration(t *testing.T) {
 	vm, err := GetVirtualMachineByVMName(whost, "test")
 	if err != nil {
@@ -198,8 +169,9 @@ func TestGetVirtualMachineOSConfiguration(t *testing.T) {
 	}
 	defer vm.Close()
 
-	_, _, err = vm.GetOSConfiguration()
+	cName, isWindows, err := vm.GetOSConfiguration()
 	if err != nil {
 		t.Fatal("Failed " + err.Error())
 	}
+	t.Logf("Retrieved OS configuration. Computer Name %s IsWindows %t", cName, isWindows)
 }

--- a/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
@@ -161,3 +161,45 @@ func TestGetVirtualMachineSetting(t *testing.T) {
 	}
 	defer setting.Close()
 }
+
+func TestGetVirtualMachineNetworkAdapterByMac(t *testing.T) {
+	vm, err := GetVirtualMachineByVMName(whost, "test")
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer vm.Close()
+
+	vna, err := vm.NewSyntheticNetworkAdapter("test1-nic1")
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer vna.Close()
+
+	macAddress, err := vna.GetPropertyAddress()
+	if err != nil {
+		t.Fatal("Failed to get MAC address " + err.Error())
+	}
+
+	if macAddress == "" {
+		t.Fatal("Empty MAC address for synthetic network adapter")
+	}
+	t.Logf("Added network interface with MAC %s", macAddress)
+
+	_, err = vm.GetVirtualGuestNetworkAdapterConfiguration(macAddress)
+	if err != nil {
+		t.Fatal("Failed to get guest network adapter config" + err.Error())
+	}
+}
+
+func TestGetVirtualMachineOSConfiguration(t *testing.T) {
+	vm, err := GetVirtualMachineByVMName(whost, "test")
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+	defer vm.Close()
+
+	_, _, err = vm.GetOSConfiguration()
+	if err != nil {
+		t.Fatal("Failed " + err.Error())
+	}
+}

--- a/pkg/virtualization/network/virtualnetworkadapter/syntheticnetworkadapter.go
+++ b/pkg/virtualization/network/virtualnetworkadapter/syntheticnetworkadapter.go
@@ -53,6 +53,5 @@ func (sna *SyntheticNetworkAdapter) GetGuestNetworkAdapterConfiguration() (guest
 	if err != nil {
 		return
 	}
-	guestConfiguration, err = NewGuestNetworkAdapterConfiguration(wmiGuestConfig)
-	return guestConfiguration, err
+	return NewGuestNetworkAdapterConfiguration(wmiGuestConfig)
 }


### PR DESCRIPTION
Testing
----------

> PS C:\Users\ndixit\source\repos\wmi> go test -v .\pkg\virtualization\core\service\... -run ^TestAddRemoveVirtualHardDisk$
> === RUN   TestAddRemoveVirtualHardDisk
> 2024/10/28 13:07:06 [WMI] QueryInstances [SELECT * FROM Msvm_VirtualSystemManagementService]=> [1]
> 2024/10/28 13:07:06 [WMI] QueryInstanceEx [SELECT * FROM Msvm_VirtualSystemManagementService]=>[1]instances
>     virtualmachinemanagementservice_test.go:661: Found [test] VMs
> ...
> ...
> ...
>     virtualmachinemanagementservice_test.go:733: Detached vhd [c:\test\tmp-3.vhdx] from [test]
> 2024/10/28 13:07:23 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:BFC4A18D-1373-415A-89AD-FD30ADE504B9\\FF7952DD-989A-4001-AC15-3F62B5A43FBE\\0\\3\\D"]
> 2024/10/28 13:07:23 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:BFC4A18D-1373-415A-89AD-FD30ADE504B9\\FF7952DD-989A-4001-AC15-3F62B5A43FBE\\0"]
> 2024/10/28 13:07:23 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:BFC4A18D-1373-415A-89AD-FD30ADE504B9\\FF7952DD-989A-4001-AC15-3F62B5A43FBE\\0\\3\\D"]
> 2024/10/28 13:07:23 [WMI] - Executing Method [RemoveResourceSettings]
> 2024/10/28 13:07:23 [WMI] - Return [0]
> 2024/10/28 13:07:23 [WMI] - Executing Method [RemoveResourceSettings]
> 2024/10/28 13:07:23 [WMI] - Return [0]
>     virtualmachinemanagementservice_test.go:733: Detached vhd [c:\test\tmp-4.vhdx] from [test]
> --- PASS: TestAddRemoveVirtualHardDisk (17.43s)
> PASS
> ok      github.com/microsoft/wmi/pkg/virtualization/core/service        17.754s
> 
> 
> PS C:\Users\ndixit\source\repos\wmi> go test -v .\pkg\virtualization\core\storage\service\... -run ^TestGetVirtualHardDiskConfig$
> === RUN   TestGetVirtualHardDiskConfig
> 2024/10/28 13:19:57 [WMI] QueryInstances [SELECT * FROM Msvm_ImageManagementService]=> [1]
> 2024/10/28 13:19:57 [WMI] QueryInstanceEx [SELECT * FROM Msvm_ImageManagementService]=>[1]instances
> 2024/10/28 13:19:57 [WMI] - Executing Method [CreateVirtualHardDisk]
> 2024/10/28 13:19:57 [WMI] - Return [4096]
> 2024/10/28 13:19:58 [WMI] - Executing Method [GetVirtualHardDiskSettingData]
> 2024/10/28 13:19:58 [WMI] - Return [0]
> 2024/10/28 13:19:58 Decoding WMI response [<INSTANCE CLASSNAME="Msvm_VirtualHardDiskSettingData"><PROPERTY NAME="BlockSize" TYPE="uint32"><VALUE>33554432</VALUE></PROPERTY><PROPERTY NAME="Caption" TYPE="string"><VALUE>Virtual Hard Disk Setting Data</VALUE></PROPERTY><PROPERTY NAME="DataAlignment" PROPAGATED="true" TYPE="uint64"></PROPERTY><PROPERTY NAME="Description" TYPE="string"><VALUE>Setting Data for a Virtual Hard Disk.</VALUE></PROPERTY><PROPERTY NAME="ElementName" TYPE="string"><VALUE>tmp.vhdx</VALUE></PROPERTY><PROPERTY NAME="Format" TYPE="uint16"><VALUE>3</VALUE></PROPERTY><PROPERTY NAME="InstanceID" TYPE="string"><VALUE>D43892B2-DD0C-4C33-8B62-F40BD93FD0F3</VALUE></PROPERTY><PROPERTY NAME="IsPmemCompatible" TYPE="boolean"><VALUE>FALSE</VALUE></PROPERTY><PROPERTY NAME="LogicalSectorSize" TYPE="uint32"><VALUE>512</VALUE></PROPERTY><PROPERTY NAME="MaxInternalSize" TYPE="uint64"><VALUE>10485760</VALUE></PROPERTY><PROPERTY NAME="ParentIdentifier" PROPAGATED="true" TYPE="string"></PROPERTY><PROPERTY NAME="ParentPath" TYPE="string"><VALUE></VALUE></PROPERTY><PROPERTY NAME="ParentTimestamp" PROPAGATED="true" TYPE="datetime"></PROPERTY><PROPERTY NAME="Path" TYPE="string"><VALUE>c:\test\tmp.vhdx</VALUE></PROPERTY><PROPERTY NAME="PhysicalSectorSize" TYPE="uint32"><VALUE>512</VALUE></PROPERTY><PROPERTY NAME="PmemAddressAbstractionType" TYPE="uint16"><VALUE>0</VALUE></PROPERTY><PROPERTY NAME="Type" TYPE="uint16"><VALUE>3</VALUE></PROPERTY><PROPERTY NAME="VirtualDiskId" TYPE="string"><VALUE>D43892B2-DD0C-4C33-8B62-F40BD93FD0F3</VALUE></PROPERTY></INSTANCE>]
> --- PASS: TestGetVirtualHardDiskConfig (1.07s)
> PASS
> ok      github.com/microsoft/wmi/pkg/virtualization/core/storage/service        3.395s
> 
> 
> PS C:\Users\ndixit\source\repos\wmi> go test -v .\pkg\virtualization\core\virtualsystem\... -run ^TestGetVirtualMachineOSConfiguration$
> 2024/10/28 14:36:05 [WMI] QueryInstances [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=> [1]
> 2024/10/28 14:36:05 [WMI] QueryInstanceEx [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=>[1]instances
> 2024/10/28 14:36:05 [WMI] QueryInstances [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=> [1]
> 2024/10/28 14:36:05 [WMI] QueryInstanceEx [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=>[1]instances
> === RUN   TestGetVirtualMachineOSConfiguration
> 2024/10/28 14:36:05 [WMI] QueryInstances [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=> [1]
> 2024/10/28 14:36:05 [WMI] QueryInstanceEx [SELECT * FROM Msvm_ComputerSystem WHERE  ElementName = 'test' ]=>[1]instances
>     virtualmachine_test.go:205: Retrieved OS configuration. Computer Name ndixit-Virtual-Machine IsWindows false
> --- PASS: TestGetVirtualMachineOSConfiguration (0.23s)
> PASS
> ok      github.com/microsoft/wmi/pkg/virtualization/core/virtualsystem  2.441s
> 
> PS C:\Users\ndixit\source\repos\wmi> go test -v .\pkg\virtualization\core\service\... -run ^TestGetVirtualMachineNetworkAdapterByMac$
> === RUN   TestGetVirtualMachineNetworkAdapterByMac
> 2024/10/28 14:58:21 [WMI] QueryInstances [SELECT * FROM Msvm_VirtualSystemManagementService]=> [1]
> 2024/10/28 14:58:21 [WMI] QueryInstanceEx [SELECT * FROM Msvm_VirtualSystemManagementService]=>[1]instances
> 2024/10/28 14:58:21 [WMI] QueryInstances [SELECT * FROM Msvm_VirtualEthernetSwitch WHERE  ElementName = 'testGen1' ]=> [1]
> 2024/10/28 14:58:21 [WMI] QueryInstanceEx [SELECT * FROM Msvm_VirtualEthernetSwitch WHERE  ElementName = 'testGen1' ]=>[1]instances
>     virtualmachinemanagementservice_test.go:662: Got VirtualSwitch[testGen1]
>     virtualmachinemanagementservice_test.go:668: Found [testGen1] VMs
>     virtualmachinemanagementservice_test.go:674: Adding VmNic with MAC to [testGen1]
> 2024/10/28 14:58:21 [WMI] QueryInstances [SELECT * FROM Cim_ResourcePool WHERE  Primordial = 'True' AND ResourceType = '10' AND ResourceSubType = 'Microsoft:Hyper-V:Synthetic Ethernet Port' ]=> [1]
> 2024/10/28 14:58:21 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_SyntheticEthernetPortSettingData.InstanceID="Microsoft:Definition\\6A45335D-4C3A-44B7-B61F-C9808BBDF8ED\\Default"]
> 2024/10/28 14:58:21 [WMI] - Executing Method [AddResourceSettings]
> 2024/10/28 14:58:21 [WMI] - Return [0]
> 2024/10/28 14:58:21 [WMI] Get Instance from path [\\CPC-ndixi-K64N2\root\virtualization\v2:Msvm_SyntheticEthernetPortSettingData.InstanceID="Microsoft:02994C59-18BB-430D-8CD0-9C9702A466B3\\944E55B4-D137-4B01-AA73-0705D27A8C13"]
>     virtualmachinemanagementservice_test.go:686: Found Adapter [testadapter]
> --- PASS: TestGetVirtualMachineNetworkAdapterByMac (0.80s)
> PASS
> ok      github.com/microsoft/wmi/pkg/virtualization/core/service        2.469s