### PR TITLE
[Placement Group] Add support for soft anti affinity

### DIFF
--- a/pkg/cluster/compute/affinityrule/affinityrule.go
+++ b/pkg/cluster/compute/affinityrule/affinityrule.go
@@ -47,8 +47,8 @@ func CreateAffinityRule(whost *host.WmiHost, name string, ruleType FailoverClust
 	defer arClass.Close()
 
 	// validate if soft anti-affinity is supported
-	isAntiAffinityRule := (ruleType == DifferentFaultDomain || ruleType == DifferentNode)
-	if isAntiAffinityRule && !strict {
+	setSoftAntiAffinity := (!strict) && (ruleType == DifferentFaultDomain || ruleType == DifferentNode)
+	if setSoftAntiAffinity {
 		if supported, err := isSoftAntiAffinitySupported(whost); err != nil {
 			return nil, err
 		} else if !supported {
@@ -82,7 +82,7 @@ func CreateAffinityRule(whost *host.WmiHost, name string, ruleType FailoverClust
 		}
 	}()
 
-	if isAntiAffinityRule && !strict {
+	if setSoftAntiAffinity {
 		if _, err := affinityRule.InvokeMethod("SetAffinityRule", int(ruleType), 1 /* Enabled */, 1 /* SoftAntiAffinity */); err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/compute/affinityrule/affinityrule.go
+++ b/pkg/cluster/compute/affinityrule/affinityrule.go
@@ -80,7 +80,7 @@ func CreateAffinityRule(whost *host.WmiHost, name string, ruleType int, strict b
 	}()
 
 	isAntiAffinityRule := (ruleType == int(DifferentFaultDomain) || ruleType == int(DifferentNode))
-	if !strict && isAntiAffinityRule && isAntiAffinitySupported(affinityRule) {
+	if !strict && isAntiAffinityRule && isSoftAntiAffinitySupported(affinityRule) {
 		_, err = affinityRule.InvokeMethod("SetAffinityRule", int(ruleType), 1 /* Enabled */, 1 /* SoftAntiAffinity */)
 		if err != nil {
 			return nil, err
@@ -122,7 +122,7 @@ func GetAffinityRule(whost *host.WmiHost, affinityRuleName string) (caffinityRul
 	return
 }
 
-func isAntiAffinitySupported(affinityRule *AffinityRule) bool {
+func isSoftAntiAffinitySupported(affinityRule *AffinityRule) bool {
 	propeties := affinityRule.GetClass().GetPropertiesNames()
 	for _, property := range propeties {
 		if strings.EqualFold(property, "SoftAntiAffinity") {

--- a/pkg/cluster/compute/affinityrule/affinityrule.go
+++ b/pkg/cluster/compute/affinityrule/affinityrule.go
@@ -39,6 +39,7 @@ func NewAffinityRule(instance *wmi.WmiInstance) (*AffinityRule, error) {
 }
 
 // CreateAffinityRule
+// Make sure to call Close once done using this instance
 func CreateAffinityRule(whost *host.WmiHost, name string, ruleType FailoverClusterAffinityRuleType, strict bool) (affinityRule *AffinityRule, err error) {
 	arClass, err := getAffinityRuleClass(whost)
 	if err != nil {
@@ -52,7 +53,7 @@ func CreateAffinityRule(whost *host.WmiHost, name string, ruleType FailoverClust
 		if supported, err := isSoftAntiAffinitySupported(whost); err != nil {
 			return nil, err
 		} else if !supported {
-			return nil, errors.Wrapf(errors.NotSupported, "Soft Anti-Affinity is not supported on this version of failover cluster")
+			return nil, errors.Wrapf(errors.NotSupported, "Soft Anti-Affinity is not supported")
 		}
 	}
 

--- a/pkg/cluster/compute/affinityrule/affinityrule.go
+++ b/pkg/cluster/compute/affinityrule/affinityrule.go
@@ -40,7 +40,7 @@ func NewAffinityRule(instance *wmi.WmiInstance) (*AffinityRule, error) {
 
 // CreateAffinityRule
 // Make sure to call Close once done using this instance
-func CreateAffinityRule(whost *host.WmiHost, name string, ruleType FailoverClusterAffinityRuleType, strict bool) (affinityRule *AffinityRule, err error) {
+func CreateAffinityRule(whost *host.WmiHost, name string, ruleType int, strict bool) (affinityRule *AffinityRule, err error) {
 	arClass, err := getAffinityRuleClass(whost)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,8 @@ func CreateAffinityRule(whost *host.WmiHost, name string, ruleType FailoverClust
 	defer arClass.Close()
 
 	// validate if soft anti-affinity is supported
-	setSoftAntiAffinity := (!strict) && (ruleType == DifferentFaultDomain || ruleType == DifferentNode)
+
+	setSoftAntiAffinity := (!strict) && (ruleType == int(DifferentFaultDomain) || ruleType == int(DifferentNode))
 	if setSoftAntiAffinity {
 		if supported, err := isSoftAntiAffinitySupported(whost); err != nil {
 			return nil, err

--- a/pkg/cluster/compute/affinityrule/affinityrule.go
+++ b/pkg/cluster/compute/affinityrule/affinityrule.go
@@ -127,7 +127,7 @@ func UpdateAffinityRule(whost *host.WmiHost, name string, ruleType int, softAnti
 		if softAntiAffinity {
 			softAntiAffinityValue = 1
 		}
-		_, err = affinityRule.InvokeMethod("SetAffinityRule", uint32(ruleType), 1 /* Enabled */, softAntiAffinityValue /* SoftAntiAffinity */)
+		_, err = affinityRule.InvokeMethod("SetAffinityRule", int(ruleType), 1 /* Enabled */, softAntiAffinityValue /* SoftAntiAffinity */)
 		if err != nil {
 			return
 		}

--- a/pkg/cluster/compute/affinityrule/affinityrule.go
+++ b/pkg/cluster/compute/affinityrule/affinityrule.go
@@ -100,7 +100,7 @@ func GetAffinityRule(whost *host.WmiHost, affinityRuleName string) (caffinityRul
 }
 
 // UpdateAffinityRule updates an existing affinity rule
-func UpdateAffinityRule(whost *host.WmiHost, name string, ruleType int, softAntiAffinity bool) (err error) {
+func SetAffinityRule(whost *host.WmiHost, name string, ruleType int, softAntiAffinity bool) (err error) {
 	affinityRule, err := GetAffinityRule(whost, name)
 	if err != nil {
 		return

--- a/pkg/cluster/compute/affinityrule/affinityrule.go
+++ b/pkg/cluster/compute/affinityrule/affinityrule.go
@@ -99,7 +99,7 @@ func GetAffinityRule(whost *host.WmiHost, affinityRuleName string) (caffinityRul
 	return
 }
 
-// UpdateAffinityRule updates an existing affinity rule
+// SetAffinityRule updates an existing affinity rule
 func SetAffinityRule(whost *host.WmiHost, name string, ruleType int, softAntiAffinity bool) (err error) {
 	affinityRule, err := GetAffinityRule(whost, name)
 	if err != nil {

--- a/pkg/cluster/storage/clustersharedvolume/clustersharedvolume.go
+++ b/pkg/cluster/storage/clustersharedvolume/clustersharedvolume.go
@@ -8,13 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"reflect"
+
 	"github.com/microsoft/wmi/pkg/base/host"
 	"github.com/microsoft/wmi/pkg/base/instance"
 	"github.com/microsoft/wmi/pkg/base/query"
 	fcconstant "github.com/microsoft/wmi/pkg/cluster/constant"
 	"github.com/microsoft/wmi/pkg/constant"
 	"github.com/microsoft/wmi/pkg/errors"
-	"reflect"
 
 	"github.com/microsoft/wmi/pkg/cluster/compute/resource"
 	wmi "github.com/microsoft/wmi/pkg/wmiinstance"
@@ -96,7 +97,9 @@ func GetClusterSharedVolumebyName(whost *host.WmiHost, name string) (cvolume *Cl
 			return
 		}
 		matchingPath := strings.ToLower(filepath.Clean(instanceName))
-		if strings.Contains(inPath, matchingPath) {
+		// Append "\\" to eliminate false positive due to partial match
+		// e.g. "C:\ClusterStorage\Volume10\image" and "C:\ClusterStorage\Volume1"
+		if strings.HasPrefix(inPath+"\\", matchingPath+"\\") {
 			tmpInstance, err1 := instance.Clone()
 			if err1 != nil {
 				err = err1

--- a/pkg/wmiinstance/WmiInstance.go
+++ b/pkg/wmiinstance/WmiInstance.go
@@ -274,7 +274,6 @@ func (c *WmiInstance) RelativePath() string {
 
 // InvokeMethod
 func (c *WmiInstance) InvokeMethod(methodName string, params ...interface{}) ([]interface{}, error) {
-	log.Printf("[WMI] Invoking method [%s] with params [%+v]\n", methodName, params)
 	rawResult, err := oleutil.CallMethod(c.instance, methodName, params...)
 	if err != nil {
 		return nil, err

--- a/pkg/wmiinstance/WmiInstance.go
+++ b/pkg/wmiinstance/WmiInstance.go
@@ -274,6 +274,7 @@ func (c *WmiInstance) RelativePath() string {
 
 // InvokeMethod
 func (c *WmiInstance) InvokeMethod(methodName string, params ...interface{}) ([]interface{}, error) {
+	log.Printf("[WMI] Invoking method [%s] with params [%+v]\n", methodName, params)
 	rawResult, err := oleutil.CallMethod(c.instance, methodName, params...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
1.  Add support for soft anti affinity
    -  To determine if FC supports SoftAntiAffinity, check if SoftAntiAffinity property is present in Affinity Rule class
3.  For containers, fix issue where wrong volume is matched due to partial prefix match.