### PR TITLE
Msvm_Tpm fix for hydration VMs

### DIFF
--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -406,13 +406,9 @@ func (vm *VirtualMachine) GetVirtualGuestNetworkAdapterConfiguration(inputMacAdd
 }
 
 func (vm *VirtualMachine) GetSecuritySettingData() (value *MsvmSecuritySettingData, err error) {
-	inst, err := vm.GetRelated("Msvm_Tpm")
-	if err != nil {
-		return nil, err
-	}
-
 	// If the TPM is not found, then it is not configured or enabled
-	if inst == nil {
+	inst, err := vm.GetRelated("Msvm_Tpm")
+	if err != nil || inst == nil {
 		return nil, nil
 	}
 	defer inst.Close()


### PR DESCRIPTION
While testing hydration, we encountered an error as follows:
`Error [Not Found\nNo Related Items were received for [Msvm_Tpm]`

It should not be considered as a failure and totally benign. This fix considers unavailability of Msvm_Tpm WMI class during Hydration of VMs. 

