### PR TITLE
Return error if corresponding volume name is found for a container

### DIFF
--- a/pkg/cluster/storage/clustersharedvolume/clustersharedvolume.go
+++ b/pkg/cluster/storage/clustersharedvolume/clustersharedvolume.go
@@ -108,7 +108,7 @@ func GetClusterSharedVolumebyName(whost *host.WmiHost, name string) (cvolume *Cl
 			return NewClusterSharedVolume(tmpInstance)
 		}
 	}
-
+	err = errors.Wrapf(errors.NotFound, "No volume found for container path %s", name)
 	return
 }
 


### PR DESCRIPTION
Issue:
During code refactoring, scenario for creating a container on a non CSV volume( or empty path) is missed.  
In this case both the csv instances and error returned nil, which caller tried to dereference as err was nil and caused crash and node agent is stuck in this state due to storing the intent in store.

Fix:
Return error if no volume is found. 