### PR TITLE
filter out snapshot from VirtualSystemSettingData

### DIFF
--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -382,6 +382,7 @@ func (vm *VirtualMachine) GetVirtualSystemSettingData() (*VirtualSystemSettingDa
 		systemType, err := vssd.GetProperty("VirtualSystemType")
 		if err != nil {
 			vssd.Close()
+			processedInstances[instance] = true // Mark as processed
 			continue
 		}
 

--- a/pkg/virtualization/core/virtualsystem/virtualmachine.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine.go
@@ -340,11 +340,39 @@ func (vm *VirtualMachine) WaitForState(state VirtualMachineState, timeoutSeconds
 }
 
 func (vm *VirtualMachine) GetVirtualSystemSettingData() (*VirtualSystemSettingData, error) {
-	inst, err := vm.GetRelated("Msvm_VirtualSystemSettingData")
+	inst, err := vm.GetAllRelated("Msvm_VirtualSystemSettingData")
 	if err != nil {
 		return nil, err
 	}
-	return NewVirtualSystemSettingData(inst)
+
+	if len(inst) == 0 {
+		return nil, errors.Wrapf(errors.NotFound, "No Related Items were received for VirtualSystemSettingData")
+	}
+
+	if len(inst) == 1 {
+		return NewVirtualSystemSettingData(inst[0])
+	}
+
+	for _, instance := range inst {
+		vssd, err := NewVirtualSystemSettingData(instance)
+		if err != nil {
+			continue
+		}
+
+		systemType, err := vssd.GetProperty("VirtualSystemType")
+		if err != nil {
+			vssd.Close()
+			continue
+		}
+
+		// filter out the snapshot realized system type
+		if systemType != "Microsoft:Hyper-V:Snapshot:Realized" {
+			return vssd, nil
+		}
+		vssd.Close()
+	}
+
+	return nil, errors.Wrapf(errors.NotFound, "Unable to find VirtualSystemSettingData for VM [%s]", vm.Name())
 }
 
 func (vm *VirtualMachine) GetVirtualGuestNetworkAdapterConfiguration(inputMacAddress string) (guestNetworkAdapterConfiguration *na.GuestNetworkAdapterConfiguration, err error) {

--- a/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
+++ b/pkg/virtualization/core/virtualsystem/virtualmachine_test.go
@@ -148,6 +148,8 @@ func TestVirtualMachineRestore(t *testing.T) {
 	}
 }
 
+// unit test can be used to test scenario where VM checkpoint is created out of band
+// create VM on hyper-v and create checkpoint using powershell
 func TestGetVirtualMachineSetting(t *testing.T) {
 	vm, err := GetVirtualMachineByVMName(whost, "test")
 	if err != nil {


### PR DESCRIPTION

If virtual machine has checkpoint we currently return first result which can belong to VM or checkpoint. This will cause unexpected failures while deleting or resizing virtual machine. This pull request fixes this issue by filtering out snapshots.