### PR TITLE
pkg/base/instance: Fix race condition in GetWmiInstanceManager

### DIFF
--- a/pkg/base/instance/instancemanager.go
+++ b/pkg/base/instance/instancemanager.go
@@ -54,20 +54,20 @@ func GetWmiInstanceManagerFromCred(hostname, namespaceName string, cred *credent
 	return GetWmiInstanceManager(hostname, namespaceName, cred.UserName, cred.Password, cred.Domain)
 }
 func GetWmiInstanceManager(hostname, namespaceName, userName, password, domainName string) (*WmiInstanceManager, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	mapId := strings.Join([]string{hostname, namespaceName, domainName}, "_")
 	if val, ok := instanceManagerMap[mapId]; ok {
 		return val, nil
 	}
 
-	mutex.Lock()
-	defer mutex.Unlock()
 	var err error
 	instanceManagerMap[mapId], err = newWmiInstanceManager(hostname, namespaceName, userName, password, domainName)
 	if err != nil {
 		return nil, err
 	}
 	return instanceManagerMap[mapId], nil
-
 }
 
 func (im *WmiInstanceManager) CreateInstance(className string) (*wmi.WmiInstance, error) {

--- a/pkg/base/instance/instancemanager_test.go
+++ b/pkg/base/instance/instancemanager_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package instance
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestGetWmiInstanceManagerConcurrently(t *testing.T) {
+	n := 2
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(name string) {
+			defer wg.Done()
+			GetWmiInstanceManager(name, "", "", "", "")
+		}(strconv.Itoa(n))
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
The global mutex is only locked during creation of the new instance manager, thus the check for its existence several lines above is not safe for concucrency.

To fix this, move the mutex lock before reading the map.

Fixes #165