### PR TITLE
Add timeout for Azure Local VM create/delete operations

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -3,6 +3,8 @@
 
 package constant
 
+import "time"
+
 type WMINamespace string
 
 const (
@@ -14,4 +16,10 @@ const (
 
 const (
 	HostName string = "localhost"
+)
+
+const (
+	// Timeout for WMI operations
+	WmiVmCreateTimeout = 60 * time.Minute
+	WmiVmDeleteTimeout = 60 * time.Minute
 )

--- a/pkg/virtualization/core/service/virtualmachine.go
+++ b/pkg/virtualization/core/service/virtualmachine.go
@@ -151,6 +151,7 @@ func (vmms *VirtualSystemManagementService) DeleteVirtualMachine(vm *virtualsyst
 		// The timeout for the VM delete call is selected based on telemetry data from Azure Local
 		result, err1 := executeVmCrudMethod(method, inparams, outparams, constant.WmiVmDeleteTimeout)
 		if err1 != nil {
+			err = err1
 			return
 		}
 

--- a/pkg/virtualization/core/service/virtualmachine.go
+++ b/pkg/virtualization/core/service/virtualmachine.go
@@ -103,12 +103,6 @@ func (vmms *VirtualSystemManagementService) CreateVirtualMachine(settings *virtu
 	// The timeout for the VM create call is selected based on telemetry data from Azure Local
 	result, err := executeVmCrudMethod(method, inparams, outparams, constant.WmiVmCreateTimeout)
 	if err != nil {
-		vmName, err2 := vm.GetPropertyElementName()
-		if err2 != nil {
-			err = errors.Wrapf(err, "VM [unknown] creation failed")
-		} else {
-			err = errors.Wrapf(err, "VM [%s] creation failed", vmName)
-		}
 		return
 	}
 
@@ -157,12 +151,6 @@ func (vmms *VirtualSystemManagementService) DeleteVirtualMachine(vm *virtualsyst
 		// The timeout for the VM delete call is selected based on telemetry data from Azure Local
 		result, err1 := executeVmCrudMethod(method, inparams, outparams, constant.WmiVmDeleteTimeout)
 		if err1 != nil {
-			vmName, err2 := vm.GetPropertyElementName()
-			if err2 != nil {
-				err = errors.Wrapf(err1, "VM [unknown] deletion failed")
-			} else {
-				err = errors.Wrapf(err1, "VM [%s] deletion failed", vmName)
-			}
 			return
 		}
 


### PR DESCRIPTION
# Problem Statement
Sometimes the VM create/delete requests are stuck for a very long time and ultimately end up in an error because of WMI provider issues - https://msazure.visualstudio.com/One/_workitems/edit/33149920
 
# Proposed solution
The solution proposed is to have a timeout for VM create and delete operations such that wssdagent does not get blocked and VM metadata is adjusted accordingly. The WMI providers usually restart in the background and can retry of the VM operation can succeed without leaving behind inconsistent data model across Azure Local stack.
 
# Testing

1. Manual testing of VM create & delete on HaaS
2. Simulate VM crud failure and timeout
```yaml
"status": {
      "errorCode": "NotSupported",
      "errorMessage": "moc-operator virtualmachine serviceClient returned an error while reconciling: nodename = v-Host1.v.masd.stbtest.microsoft.com: VM [testvm7] creation failed: Not Supported",
      "powerState": null,
      "provisioningStatus": {
        "operationId": "e2f72ba0-630a-4825-938a-b842cb96e79b*67216E1A93B5C6AB9AC785D90131D207D48803A1EE74C10152C874153E7EA50E",
        "status": "Failed"
      }
    }

"status": {
      "errorCode": "Failed",
      "errorMessage": "moc-operator virtualmachine serviceClient returned an error while reconciling: nodename = v-Host3.v.masd.stbtest.microsoft.com: VM [testvm8] creation failed: WMI method [DefineSystem] timeout after 1s: Timedout",
      "powerState": null,
      "provisioningStatus": {
        "operationId": "36ae312b-a178-4733-84f4-e17a73c1fe71*357E50BA9DF509F86C3FF144A9DE21CFFDD9DF10BA7FD7AD8C0CE2A0FBFAEBBF",
        "status": "Failed"
      }
    }
```

4. E2E test run 
```yaml
Total tests: 13
     Passed: 12
     Failed: 1
 Total time: 3.1018 Hours
```
The one test failure is related to IP address not reachable for Linux VM and its not related to the VM creation changes. Here are the detailed results

```xml
<Results>
    <UnitTestResult executionId="3a6a4962-1e64-4324-99d6-1e1ead2f0674" testId="78e0cbd1-1d50-6279-f4fa-22e45c7cd5e9" testName="DeleteVirtualMachine" computerName="V-DVM" duration="00:12:37.3132004" startTime="2025-06-13T20:14:31.5118988+00:00" endTime="2025-06-13T20:27:08.8327598+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3a6a4962-1e64-4324-99d6-1e1ead2f0674" />
    <UnitTestResult executionId="fb91e64a-244f-4350-8676-ea99ef9d7840" testId="e187c090-f66f-be64-3aaa-beb01ac2543f" testName="GuestManagementCreation_Win_StaticIP" computerName="V-DVM" duration="00:11:10.0991155" startTime="2025-06-13T20:27:08.8327598+00:00" endTime="2025-06-13T20:42:40.3018864+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fb91e64a-244f-4350-8676-ea99ef9d7840" />
    <UnitTestResult executionId="6c1d0a7d-c695-4e33-b282-0b56543a4757" testId="9a821ce5-9134-e735-fdd9-6ef2b5f77b1d" testName="Update_VirtualMachine_MemoryMb_OnStoppedVM" computerName="V-DVM" duration="00:07:40.4499961" startTime="2025-06-13T19:59:41.5996258+00:00" endTime="2025-06-13T20:07:22.0540129+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6c1d0a7d-c695-4e33-b282-0b56543a4757" />
    <UnitTestResult executionId="734bace6-c2dc-466b-9e87-7155a8d061af" testId="7458dd40-99af-a146-fa40-ca2162a2a5ad" testName="UpdateVirtualMachine_MemoryMb" computerName="V-DVM" duration="00:07:44.1736188" startTime="2025-06-13T19:50:36.2644031+00:00" endTime="2025-06-13T19:59:41.5996258+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="734bace6-c2dc-466b-9e87-7155a8d061af" />
    <UnitTestResult executionId="a5236c04-45de-42bf-841d-108d073e10f7" testId="3a628c13-7539-01c7-f993-458836ea50dc" testName="CreateGetListDeleteGalleryImageTest" computerName="V-DVM" duration="00:15:29.3505856" startTime="2025-06-13T17:59:31.6990495+00:00" endTime="2025-06-13T18:16:02.8139695+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a5236c04-45de-42bf-841d-108d073e10f7" />
    <UnitTestResult executionId="cb1a86ef-13cb-4aca-a53e-560b467216c6" testId="338e53b8-9d9a-fce9-cc95-3bf88b337f34" testName="GuestManagementCreation_Linux_StaticIP" computerName="V-DVM" duration="00:20:17.5492745" startTime="2025-06-13T20:42:40.3018864+00:00" endTime="2025-06-13T21:05:36.5493622+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cb1a86ef-13cb-4aca-a53e-560b467216c6" />
    <UnitTestResult executionId="904acc85-2f11-4132-9520-295c17625549" testId="5563c4f3-724f-b16d-3715-998be13906be" testName="CreateVirtualMachine_Win_lNet" computerName="V-DVM" duration="00:09:40.6847693" startTime="2025-06-13T19:15:21.0854900+00:00" endTime="2025-06-13T19:25:01.7757812+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="904acc85-2f11-4132-9520-295c17625549" />
    <UnitTestResult executionId="49d4f8cd-cba2-42c4-b9cb-b33ebcbb8f73" testId="89cdfb15-19fd-e777-f3ba-1082aa704e45" testName="StopVirtualMachineFromAZCli" computerName="V-DVM" duration="00:07:09.4541788" startTime="2025-06-13T20:07:22.0540129+00:00" endTime="2025-06-13T20:14:31.5118988+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="49d4f8cd-cba2-42c4-b9cb-b33ebcbb8f73" />
    <UnitTestResult executionId="64d862c1-e1b8-42ed-b231-37a426677b82" testId="9a4b282c-175b-c20b-c087-01d9f0d2f23a" testName="Create_VirtualMachine_Win_StaticIP_VLAN" computerName="V-DVM" duration="00:11:07.8103342" startTime="2025-06-13T19:39:28.4478887+00:00" endTime="2025-06-13T19:50:36.2644031+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="64d862c1-e1b8-42ed-b231-37a426677b82" />
    <UnitTestResult executionId="f72769ac-e74e-4957-b051-ce454630b4f1" testId="10d26237-a360-ee32-cf0b-ea3a127c0a1b" testName="CreateVirtualMachine_Win_MixedcaseName" computerName="V-DVM" duration="00:07:22.2311706" startTime="2025-06-13T18:49:24.7236196+00:00" endTime="2025-06-13T19:10:58.4713006+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f72769ac-e74e-4957-b051-ce454630b4f1" />
    <UnitTestResult executionId="f6f04042-6d39-4918-912f-1c17deb68c06" testId="20e4e73f-e58a-09ca-7c81-b613e61f4797" testName="CreateMarketPlaceImage_Win_LowerCaseName" computerName="V-DVM" duration="00:33:21.8602080" startTime="2025-06-13T18:16:02.8339626+00:00" endTime="2025-06-13T18:49:24.7236196+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f6f04042-6d39-4918-912f-1c17deb68c06" />
    <UnitTestResult executionId="9531ba65-1778-427d-9ecb-c02fde6ce25a" testId="0e1c2e82-ea4f-9b57-1f4f-2aa0cd0b042c" testName="CreateVirtualMachine_Linux_lNet" computerName="V-DVM" duration="00:14:26.6635417" startTime="2025-06-13T19:25:01.7757812+00:00" endTime="2025-06-13T19:39:28.4478887+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9531ba65-1778-427d-9ecb-c02fde6ce25a">
      <Output>
        <ErrorInfo>
          <Message>Assert.Fail failed. Access vM linux-vm-lnet-4-bqEFEE error, Assert.Fail failed. vm linux-vm-lnet-4-bqEFEE ip address is null</Message>
          <StackTrace>   at TestHelper.TestHelper.AccessVM(String vmName, OsProfile osProfile, Boolean failOnAccessVM, UInt32 retryCount, Int32 retryMinutes)&#xD;
   at TestHelper.TestHelper.ValidateAndAccessVM(VirtualMachine vm, VMPowerState expectedVMStatus, VMHyperVState expectedVMHyperVStatus, OsProfile osProfile, Boolean failOnAccessVM, HttpProxyConfig proxyConfig, UInt32 retryCount, Int32 retryMinutes)&#xD;
   at TestHelper.TestHelper.CreateVirtualMachineAndValidateVM(VirtualMachine vM, Boolean enableAgent, String sshPublicKeys, String adminUsername, String adminPassword, String computerName, String nicId, String vmSize, String imageReference, VMPowerState expectedVMStatus, VMHyperVState expectedVMHyperVStatus, String authType, UInt32 retryAttempts, Nullable`1 retryInterval, ArcClusterNode clusterNode, VMSecurityType vMSecurityType, Boolean enableVmConfigAgent, String gpus)&#xD;
   at ArcVME2ETests.ArcVME2EVMCreationTests.CreateVirtualMachine(Boolean enableAgent, String sshPublicKeys, String adminUsername, String adminPassword, String computerName, String nicId, String vmSize, String imageReference, String authType, Boolean enableVmConfigAgent)&#xD;
   at ArcVME2ETests.ArcVME2EVMCreationTests.CreateVirtualMachine_Linux_lNet()&#xD;
</StackTrace>
        </ErrorInfo>
      </Output>
    </UnitTestResult>
    <UnitTestResult executionId="3e003df1-9e6c-4383-99ac-75c969b8529e" testId="75514819-6e2d-e95f-5fb7-78c9e7390788" testName="CreateVirtualMachine_Linux_MixedcaseName" computerName="V-DVM" duration="00:04:22.6111999" startTime="2025-06-13T19:10:58.4713006+00:00" endTime="2025-06-13T19:15:21.0854900+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3e003df1-9e6c-4383-99ac-75c969b8529e" />
  </Results>
```