### PR TITLE
ISO & DVD cleanup for Arc VMs - Part 3

### DIFF
--- a/pkg/virtualization/core/service/virtualmachinemanagementservice.go
+++ b/pkg/virtualization/core/service/virtualmachinemanagementservice.go
@@ -294,11 +294,12 @@ func (vmms *VirtualSystemManagementService) RemoveVirtualSystemResource(
 			return
 		}
 
-		// Try to get the Out Params
+		// Return immediately if result is success
 		if result.ReturnValue == constant.Success {
 			return
 		}
 
+		// If WMI method returns job, return after job completion
 		val := result.OutMethodParams["Job"]
 		job, err1 := instance.GetWmiJob(vmms.GetWmiHost(), string(constant.Virtualization), val.Value.(string))
 		if err1 != nil {
@@ -307,7 +308,7 @@ func (vmms *VirtualSystemManagementService) RemoveVirtualSystemResource(
 		}
 		defer job.Close()
 
-		err = job.WaitForJobCompletion(result.ReturnValue, timeoutSeconds)
+		return job.WaitForJobCompletion(result.ReturnValue, timeoutSeconds)
 	}
 }
 


### PR DESCRIPTION
**Proposed Solution**
An infinite loop was seen during VM migrate scenarios only (The usual VM crud was passing without any issues). I think the use of non sysprepped by VM migration images triggered this scenario of async job which always led to an infinite loop.
 
In this PR I added an explicit return statement on line 311 which prevented this infinite loop.

### **Testing**
**E2E VM BVT - All Pass**
<img width="1111" height="187" alt="image" src="https://github.com/user-attachments/assets/b52d8a57-57f5-4b8d-b6b1-bac857e84711" />

**Manual VM CRUD for Gen2 VMs - All Pass**

**Manual VM CRUD for Gen1 VMs - All Pass**
<img width="1462" height="777" alt="image" src="https://github.com/user-attachments/assets/434d5228-dd5b-4d12-96e8-7b9ed652f0db" />
