### PR TITLE
Add IsEnabled() helper to Win32Service

### DIFF
--- a/pkg/operatingsystem/core/service/service.go
+++ b/pkg/operatingsystem/core/service/service.go
@@ -118,15 +118,9 @@ func (ws *Win32Service) IsRunning() (bool, error) {
 // Control Manager, so callers that poll IsRunning should first check
 // IsEnabled to avoid waiting on a service that will never start.
 func (ws *Win32Service) IsEnabled() (bool, error) {
-	rawStartMode, err := ws.GetProperty("StartMode")
+	startMode, err := ws.GetPropertyStartMode()
 	if err != nil {
 		return false, err
-	}
-
-	startMode, ok := rawStartMode.(string)
-	if !ok {
-		return false, errors.Wrapf(errors.InvalidType,
-			"Win32_Service StartMode property is not a string (got %T)", rawStartMode)
 	}
 
 	return startMode != SERVICE_START_MODE_DISABLED, nil

--- a/pkg/operatingsystem/core/service/service.go
+++ b/pkg/operatingsystem/core/service/service.go
@@ -27,6 +27,16 @@ const (
 	SERVICE_PAUSED           string = "Paused"
 )
 
+// Win32_Service.StartMode property values.
+// See: https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-service
+const (
+	SERVICE_START_MODE_BOOT     string = "Boot"
+	SERVICE_START_MODE_SYSTEM   string = "System"
+	SERVICE_START_MODE_AUTO     string = "Auto"
+	SERVICE_START_MODE_MANUAL   string = "Manual"
+	SERVICE_START_MODE_DISABLED string = "Disabled"
+)
+
 type Win32Service struct {
 	*cimv2.Win32_Service
 }
@@ -101,4 +111,23 @@ func (ws *Win32Service) IsRunning() (bool, error) {
 	}
 
 	return false, nil
+}
+
+// IsEnabled returns true when the service's StartMode is anything other
+// than "Disabled". A disabled service cannot be started by the Service
+// Control Manager, so callers that poll IsRunning should first check
+// IsEnabled to avoid waiting on a service that will never start.
+func (ws *Win32Service) IsEnabled() (bool, error) {
+	rawStartMode, err := ws.GetProperty("StartMode")
+	if err != nil {
+		return false, err
+	}
+
+	startMode, ok := rawStartMode.(string)
+	if !ok {
+		return false, errors.Wrapf(errors.InvalidType,
+			"Win32_Service StartMode property is not a string (got %T)", rawStartMode)
+	}
+
+	return startMode != SERVICE_START_MODE_DISABLED, nil
 }

--- a/pkg/operatingsystem/core/service/service_test.go
+++ b/pkg/operatingsystem/core/service/service_test.go
@@ -62,6 +62,30 @@ func TestWin32_Service_IsEnabled(t *testing.T) {
 	fmt.Printf("Win32Service BFE is enabled : %t\n", isEnabled)
 }
 
+func TestWin32_Service_IsEnabled_Disabled(t *testing.T) {
+	whost := host.NewWmiLocalHost()
+	// NetTcpPortSharing ships disabled by default on Windows client and
+	// server SKUs, so its StartMode is "Disabled" unless an admin has
+	// explicitly enabled it. If this test is being run on a host where
+	// it's been enabled, the test is skipped rather than failed.
+	win32svc, err := GetWin32Service(whost, "NetTcpPortSharing")
+	if err != nil {
+		t.Skipf("NetTcpPortSharing service not present on this host: %v", err)
+	}
+	defer win32svc.Close()
+
+	isEnabled, err := win32svc.IsEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if isEnabled {
+		t.Skip("NetTcpPortSharing is enabled on this host; cannot validate disabled path")
+	}
+
+	fmt.Printf("Win32Service NetTcpPortSharing is enabled : %t\n", isEnabled)
+}
+
 func TestWin32_Service_Doesnot_Exist(t *testing.T) {
 	whost := host.NewWmiLocalHost()
 	_, err := GetWin32Service(whost, "InvalidService")

--- a/pkg/operatingsystem/core/service/service_test.go
+++ b/pkg/operatingsystem/core/service/service_test.go
@@ -40,6 +40,28 @@ func TestWin32_Service_Exists2(t *testing.T) {
 	fmt.Printf("Win32Service is running : %t\n", isRunning)
 }
 
+func TestWin32_Service_IsEnabled(t *testing.T) {
+	whost := host.NewWmiLocalHost()
+	// BFE (Base Filtering Engine) is auto-started on every Windows host,
+	// so its StartMode is never "Disabled".
+	win32svc, err := GetWin32Service(whost, "BFE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer win32svc.Close()
+
+	isEnabled, err := win32svc.IsEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isEnabled {
+		t.Fatalf("BFE is expected to be enabled, but IsEnabled returned false")
+	}
+
+	fmt.Printf("Win32Service BFE is enabled : %t\n", isEnabled)
+}
+
 func TestWin32_Service_Doesnot_Exist(t *testing.T) {
 	whost := host.NewWmiLocalHost()
 	_, err := GetWin32Service(whost, "InvalidService")


### PR DESCRIPTION
## Summary

Adds a typed IsEnabled() helper on `Win32Service` so callers can short-circuit polling loops when a Windows service is administratively disabled.

A disabled service cannot be started by the Service Control Manager, so calling sites that poll `IsRunning()` in a wait loop end up burning the entire timeout on hosts where the service is configured `StartMode = Disabled`. With `IsEnabled()` those callers can detect this case and skip the wait immediately.

### Motivating case

[microsoft/moc-pkg `pkg/failovercluster/fc_windows.go`](https://github.com/microsoft/moc-pkg/blob/master/pkg/failovercluster/fc_windows.go) `waitForFailoverCluster()` polls `ClusSvc.IsRunning()` for **300 seconds** before giving up. On hosts where the Failover Cluster role is not installed, `ClusSvc` exists but is `Disabled` — so every startup of a moc-pkg consumer (e.g. wssdagent) blocks for 5 minutes for no reason. A follow-up moc-pkg PR will adopt `IsEnabled()` to short-circuit that loop.

## Changes

- `pkg/operatingsystem/core/service/service.go`
  - Add five `SERVICE_START_MODE_*` constants (`Boot` / `System` / `Auto` / `Manual` / `Disabled`) for symmetry with the existing `SERVICE_*` service-state constants.
  - Add `IsEnabled() (bool, error)` method that reads the `StartMode` property via the embedded `WmiInstance.GetProperty` and returns `true` iff it is not `Disabled`.
- `pkg/operatingsystem/core/service/service_test.go`
  - Add `TestWin32_Service_IsEnabled` covering the BFE service (always auto-started on Windows).

## Testing

- `go build ./pkg/operatingsystem/core/service/...` — clean
- `go vet ./pkg/operatingsystem/core/service/...` — clean
- New test `TestWin32_Service_IsEnabled` follows the existing `TestWin32_Service_Exists*` pattern (runs against the local Windows host; BFE is present on every supported SKU).

## Compatibility

Purely additive — no existing public surface changes. `IsRunning()` semantics are unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>